### PR TITLE
fix add contacts empty name.

### DIFF
--- a/lib/ui/home/chat_slide_page/chat_info_page.dart
+++ b/lib/ui/home/chat_slide_page/chat_info_page.dart
@@ -578,7 +578,7 @@ class _AddToContactsButton extends StatelessWidget {
                   ),
                   onPressed: () {
                     final username = conversation.user?.fullName ??
-                        conversation.conversation?.name;
+                        conversation.conversation?.validName;
                     assert(username != null,
                         'ContactsAdd: username should not be null.');
                     assert(conversation.isGroup != true,


### PR DESCRIPTION
if a user conversation create from group, `conversation.user` might be null.