### PR TITLE
fix contact message wrong isPlain

### DIFF
--- a/lib/ui/home/chat_slide_page/chat_info_page.dart
+++ b/lib/ui/home/chat_slide_page/chat_info_page.dart
@@ -123,7 +123,7 @@ class ChatInfoPage extends HookWidget {
                             accountServer.sendContactMessage(
                               conversation.userId!,
                               conversation.name!,
-                              conversation.isPlainConversation,
+                              isPlain(result.first.isGroup, result.first.isBot),
                               conversationId: conversationId,
                               recipientId: result[0].userId,
                             ));


### PR DESCRIPTION
contact message use destination conversation to check`isPlain` instead of current conversation.