### PR TITLE
remove conversation assertion

### DIFF
--- a/lib/widgets/message/message_datetime_and_status.dart
+++ b/lib/widgets/message/message_datetime_and_status.dart
@@ -19,13 +19,11 @@ bool _isRepresentative(
   MessageItem message,
   ConversationState? conversation,
   String userId,
-) {
-  assert(conversation != null);
-  return conversation != null &&
-      (conversation.isBot ?? false) &&
-      (conversation.user?.userId != message.userId) &&
-      (message.userId != userId);
-}
+) =>
+    conversation != null &&
+    (conversation.isBot ?? false) &&
+    (conversation.user?.userId != message.userId) &&
+    (message.userId != userId);
 
 class MessageDatetimeAndStatus extends StatelessWidget {
   const MessageDatetimeAndStatus({


### PR DESCRIPTION
fix
```log
'package:flutter_app/widgets/message/message_datetime_and_status.dart': Failed assertion: line 23 pos 10: 'conversation != null': is not true.

The relevant error-causing widget was: 
  MessageDatetimeAndStatus MessageDatetimeAndStatus:file:///C:/Users/yangbin/workspace/mixin/flutter-app/lib/widgets/message/item/text/text_message.dart:104:27
When the exception was thrown, this was the stack: 
#2      _isRepresentative (package:flutter_app/widgets/message/message_datetime_and_status.dart:23:10)
#3      MessageDatetimeAndStatus.build (package:flutter_app/widgets/message/message_datetime_and_status.dart:54:15)

```