### PR TITLE
Fix baseline for emoji

### DIFF
--- a/lib/ui/home/conversation_page.dart
+++ b/lib/ui/home/conversation_page.dart
@@ -1223,6 +1223,7 @@ class _MessageContent extends HookWidget {
               style: TextStyle(
                 color: dynamicColor,
                 fontSize: 14,
+                height: 1,
               ),
               overflow: TextOverflow.ellipsis,
               maxLines: 1,


### PR DESCRIPTION
When text have emoji, the baseline will get weird