### PR TITLE
fix box has already been closed error.

### DIFF
--- a/lib/account/account_server.dart
+++ b/lib/account/account_server.dart
@@ -596,6 +596,8 @@ class AccountServer {
     await Future.wait(jobSubscribers.map((s) => s.cancel()));
     jobSubscribers.clear();
     await clearKeyValues();
+    // Re-init keyValue to prepare for next login.
+    await initKeyValues();
     await SignalDatabase.get.clear();
     await database.participantSessionDao.deleteBySessionId(sessionId);
     await database.participantSessionDao.updateSentToServer();


### PR DESCRIPTION
When the device is logout by another device, relogin will trigger this exception, making it impossible to log in again.