### PR TITLE
Disable ansi color on platform iOS.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,7 +62,7 @@ Future<void> main(List<String> args) async {
   if (kDebugMode) Bloc.observer = CustomBlocObserver();
   unawaited(initListener());
 
-  ansiColorDisabled = false;
+  ansiColorDisabled = Platform.isIOS;
   DartVLC.initialize();
   runZonedGuarded(
     () => runApp(const App()),


### PR DESCRIPTION
ansi colorred log do not work on iOS