### PR TITLE
Improve unseen count update performance.

### DIFF
--- a/lib/account/account_server.dart
+++ b/lib/account/account_server.dart
@@ -265,17 +265,15 @@ class AccountServer {
     if (floodMessages.isEmpty) {
       return;
     }
+    Stopwatch? stopwatch;
+    if (!kReleaseMode) {
+      stopwatch = Stopwatch()..start();
+    }
     for (final message in floodMessages) {
-      Stopwatch? stopwatch;
-      if (!kReleaseMode) {
-        stopwatch = Stopwatch()..start();
-      }
-
       await _decryptMessage.process(message);
-
-      if (stopwatch != null) {
-        d('process execution time: ${stopwatch.elapsedMilliseconds}');
-      }
+    }
+    if (stopwatch != null) {
+      d('processMessage(${floodMessages.length}): ${stopwatch.elapsedMilliseconds}');
     }
     await _runProcessFloodJob();
   }

--- a/lib/db/mixin_database.dart
+++ b/lib/db/mixin_database.dart
@@ -96,7 +96,7 @@ class MixinDatabase extends _$MixinDatabase {
   MixinDatabase.connect(DatabaseConnection c) : super.connect(c);
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   final eventBus = DataBaseEventBus();
 
@@ -161,6 +161,9 @@ class MixinDatabase extends _$MixinDatabase {
           }
           if (from <= 7) {
             await m.drop(Trigger('', 'conversation_last_message_update'));
+          }
+          if (from <= 8) {
+            await m.createIndex(indexMessageConversationIdStatusUserId);
           }
         },
       );

--- a/lib/db/moor/dao/message.drift
+++ b/lib/db/moor/dao/message.drift
@@ -257,3 +257,9 @@ SELECT m.message_id messageId, u.user_id AS userId, u.avatar_url AS userAvatarUr
     WHERE m.conversation_id = :conversationId AND m.user_id = :userId AND m.message_id IN (SELECT message_id FROM messages_fts WHERE messages_fts MATCH :query)
     ORDER BY m.created_at DESC
     LIMIT :limit OFFSET :offset;
+
+
+updateUnseenMessageCount:
+UPDATE conversations SET unseen_message_count
+    = (SELECT count(1) FROM messages WHERE conversation_id = :conversationId AND status IN ('SENT', 'DELIVERED')  AND user_id != :userId)
+    WHERE conversation_id = :conversationId;

--- a/lib/db/moor/mixin.drift
+++ b/lib/db/moor/mixin.drift
@@ -73,5 +73,6 @@ CREATE INDEX IF NOT EXISTS index_messages_conversation_id_created_at ON messages
 CREATE INDEX IF NOT EXISTS index_participants_conversation_id_created_at ON participants(conversation_id, created_at);
 CREATE INDEX IF NOT EXISTS index_sticker_albums_category_created_at ON sticker_albums(category, created_at DESC);
 CREATE INDEX IF NOT EXISTS index_pin_messages_conversation_id ON pin_messages(conversation_id);
+CREATE INDEX IF NOT EXISTS index_message_conversation_id_status_user_id ON messages(conversation_id, status, user_id);
 
 CREATE TRIGGER IF NOT EXISTS conversation_last_message_delete AFTER DELETE ON messages BEGIN UPDATE conversations SET last_message_id = (select message_id from messages where conversation_id = old.conversation_id order by created_at DESC limit 1) WHERE conversation_id = old.conversation_id; END;


### PR DESCRIPTION
add a new index to table `messages` 
```sql
CREATE INDEX IF NOT EXISTS index_message_conversation_id_status_user_id ON messages(conversation_id, status, user_id);
```

improve update performance when a conversation contains many messages.