### PR TITLE
Fix image preview dialog pop.

### DIFF
--- a/lib/widgets/message/item/image/image_preview_page.dart
+++ b/lib/widgets/message/item/image/image_preview_page.dart
@@ -464,7 +464,7 @@ class _Item extends HookWidget {
             maxScale: math.max(initialScale * 2, 2),
             controller: controller,
             onEmptyAreaTapped: () {
-              Navigator.pop(context);
+              Navigator.maybePop(context);
             },
             image: Image.file(
               File(context.accountServer


### PR DESCRIPTION
when click empty area on image preview page and then click key `ESC` fast, it may cause main window page got poped.