### PR TITLE
fix attachment assert.

### DIFF
--- a/lib/utils/attachment/attachment_util.dart
+++ b/lib/utils/attachment/attachment_util.dart
@@ -267,7 +267,7 @@ class AttachmentUtil extends ChangeNotifier {
     String category, {
     String? transcriptId,
   }) async {
-    assert(_hasAttachmentJob(messageId));
+    assert(!_hasAttachmentJob(messageId));
     await _messageDao.updateMediaStatus(messageId, MediaStatus.pending);
 
     try {


### PR DESCRIPTION
fix send image message on debug version.

```log
[ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: 'package:flutter_app/utils/attachment/attachment_util.dart': Failed assertion: line 270 pos 12: '_hasAttachmentJob(messageId)': is not true.
#0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:51:61)
#1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:40:5)
#2      AttachmentUtil.uploadAttachment (package:flutter_app/utils/attachment/attachment_util.dart:270:12)
#3      SendMessageHelper.sendImageMessage (package:flutter_app/account/send_message_helper.dart:179:31)
<asynchronous suspension>
```