### PR TITLE
Remove outdated dependency_overrides.

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -16,7 +16,7 @@ packages:
     source: hosted
     version: "1.0.0"
   analyzer:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
@@ -365,21 +365,17 @@ packages:
   drift:
     dependency: "direct main"
     description:
-      path: drift
-      ref: "70e83b5a747cb6bf9bf360d6de78e8398d3b6873"
-      resolved-ref: "70e83b5a747cb6bf9bf360d6de78e8398d3b6873"
-      url: "https://github.com/simolus3/moor.git"
-    source: git
-    version: "1.2.0-dev"
+      name: drift
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   drift_dev:
     dependency: "direct dev"
     description:
-      path: drift_dev
-      ref: "70e83b5a747cb6bf9bf360d6de78e8398d3b6873"
-      resolved-ref: "70e83b5a747cb6bf9bf360d6de78e8398d3b6873"
-      url: "https://github.com/simolus3/moor.git"
-    source: git
-    version: "1.2.0-dev"
+      name: drift_dev
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   ecache:
     dependency: "direct main"
     description:
@@ -1028,7 +1024,7 @@ packages:
     source: git
     version: "0.11.1"
   platform:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
@@ -1208,7 +1204,7 @@ packages:
       name: sqlite3
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.5.1"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -1217,14 +1213,12 @@ packages:
     source: hosted
     version: "0.5.2"
   sqlparser:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: sqlparser
-      ref: "70e83b5a747cb6bf9bf360d6de78e8398d3b6873"
-      resolved-ref: "70e83b5a747cb6bf9bf360d6de78e8398d3b6873"
-      url: "https://github.com/simolus3/moor.git"
-    source: git
-    version: "0.19.0"
+      name: sqlparser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.19.2"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   desktop_webview_window: ^0.1.6
   device_info_plus: ^3.1.0
   dio: ^4.0.0
-  drift: ^1.0.1
+  drift: ^1.3.0
   ecache: ^2.0.1
   equatable: ^2.0.3
   extended_image: ^4.1.0
@@ -108,7 +108,6 @@ dependencies:
       ref: 57a2cd88486105d3d813583339eb0e23c9bfd6d2
 
 dependency_overrides:
-  analyzer: ^2.2.0
   bitsdojo_window_linux:
     git:
       url: https://github.com/MixinNetwork/bitsdojo_window.git
@@ -119,31 +118,15 @@ dependency_overrides:
       url: https://github.com/MixinNetwork/bitsdojo_window.git
       ref: 78faaa6440c7fee146258bb0ef3336c33ed4555d
       path: bitsdojo_window_windows
-  drift:
-    git:
-      url: https://github.com/simolus3/moor.git
-      ref: 70e83b5a747cb6bf9bf360d6de78e8398d3b6873
-      path: drift
-  drift_dev:
-    git:
-      url: https://github.com/simolus3/moor.git
-      ref: 70e83b5a747cb6bf9bf360d6de78e8398d3b6873
-      path: drift_dev
   # remove this if https://github.com/woodemi/quick_breakpad/issues/10 fixed
-  platform: ^3.1.0
   quick_breakpad:
     git:
       url: https://github.com/boyan01/quick_breakpad
       ref: 33e9af863352430b6a9b1dedffb757819a3ff020
-  sqlparser:
-    git:
-      url: https://github.com/simolus3/moor.git
-      ref: 70e83b5a747cb6bf9bf360d6de78e8398d3b6873
-      path: sqlparser
 
 dev_dependencies:
   build_runner:
-  drift_dev: ^1.0.2
+  drift_dev: ^1.3.0
   flutter_test:
     sdk: flutter
   hive_generator: ^1.1.0


### PR DESCRIPTION
upgrade drift to pub.dev version 1.3.0

remove analyzer and platform package version constraints.