### PR TITLE
remove escapeFts5 unnecessary quotation marks

### DIFF
--- a/lib/utils/extension/src/string.dart
+++ b/lib/utils/extension/src/string.dart
@@ -96,7 +96,7 @@ String maxOf(String a, String b) {
 extension SqlStringExt on String {
   String escapeSql() => RegExp.escape(this);
 
-  String escapeFts5() => '"${escapeSql().joinStar().replaceQuotationMark()}"';
+  String escapeFts5() => escapeSql().joinStar().replaceQuotationMark();
 
   String joinStar() => joinWithCharacter('*');
 


### PR DESCRIPTION
fix search message with keyword `abc` can not match the text `abcdefg`