### PR TITLE
fix chat page text selection background box height

### DIFF
--- a/lib/ui/home/chat/input_container.dart
+++ b/lib/ui/home/chat/input_container.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui' as ui show BoxHeightStyle;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -524,6 +525,7 @@ class _SendTextField extends HookWidget {
                 bottom: 8,
               ),
             ),
+            selectionHeightStyle: ui.BoxHeightStyle.includeLineSpacingMiddle,
           ),
         ),
       ),

--- a/lib/widgets/high_light_text.dart
+++ b/lib/widgets/high_light_text.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui show BoxHeightStyle;
+
 import 'package:equatable/equatable.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -106,6 +108,7 @@ class HighlightSelectableText extends HookWidget {
       maxLines: maxLines,
       textWidthBasis: TextWidthBasis.longestLine,
       toolbarOptions: const ToolbarOptions(),
+      selectionHeightStyle: ui.BoxHeightStyle.includeLineSpacingMiddle,
     );
   }
 }


### PR DESCRIPTION
according https://github.com/flutter/flutter/issues/68675. we can use `includeLineSpacingMiddle` as ` SelectableText.selectionHeightStyle`