### PR TITLE
bump win_toast to 0.1.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1637,7 +1637,7 @@ packages:
       name: win_toast
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.1"
   window_size:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -116,7 +116,7 @@ dependencies:
   web_socket_channel: ^2.2.0
   webview_flutter: ^3.0.4
   win32: ^2.6.1
-  win_toast: ^0.1.0
+  win_toast: ^0.1.1
   window_size:
     git:
       url: https://github.com/google/flutter-desktop-embedding.git


### PR DESCRIPTION
https://github.com/MixinNetwork/flutter-plugins/commit/6f8458fed6de65bf119d4812b2186c03d8c4b7b2

fix `GetCurrentPackageFullName` didn't work on win7