### PR TITLE
fix command+w can not close webview window on macOS

### DIFF
--- a/lib/widgets/window/menus.dart
+++ b/lib/widgets/window/menus.dart
@@ -274,10 +274,6 @@ class _Menus extends HookWidget {
               PlatformMenuItemGroup(members: [
                 PlatformMenuItem(
                   label: context.l10n.closeWindow,
-                  shortcut: const SingleActivator(
-                    LogicalKeyboardKey.keyW,
-                    meta: true,
-                  ),
                   onSelected: windowManager.close,
                 )
               ]),


### PR DESCRIPTION
remove menu bar shortcut for close window action, replace by https://github.com/MixinNetwork/flutter-app/blob/main/lib/widgets/window/window_shortcuts.dart