### PR TITLE
Add a workaround for TextField delete on macOS. 

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -30,6 +30,7 @@ import 'utils/extension/extension.dart';
 import 'utils/hook.dart';
 import 'utils/logger.dart';
 import 'utils/system/system_fonts.dart';
+import 'utils/system/text_input.dart';
 import 'utils/system/tray.dart';
 import 'widgets/brightness_observer.dart';
 import 'widgets/focus_helper.dart';
@@ -226,7 +227,11 @@ class _App extends StatelessWidget {
                         ? textScaleFactor
                         : mediaQueryData.textScaleFactor,
                   ),
-                  child: SystemTrayWidget(child: child!),
+                  child: SystemTrayWidget(
+                    child: TextInputActionHandler(
+                      child: child!,
+                    ),
+                  ),
                 ),
               );
             },

--- a/lib/utils/system/text_input.dart
+++ b/lib/utils/system/text_input.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+
+import '../logger.dart';
+
+// remove this once https://github.com/flutter/flutter/issues/111113 is fixed.
+class TextInputActionHandler extends StatefulWidget {
+  const TextInputActionHandler({
+    super.key,
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  State<TextInputActionHandler> createState() => _TextInputActionHandlerState();
+}
+
+class _TextInputActionHandlerState extends State<TextInputActionHandler> {
+  late final _actions = <Type, Action<Intent>>{
+    DeleteCharacterIntent: makeAction<DeleteCharacterIntent>(context),
+    ExtendSelectionByCharacterIntent:
+        makeAction<ExtendSelectionByCharacterIntent>(context),
+    ExtendSelectionVerticallyToAdjacentLineIntent:
+        makeAction<ExtendSelectionVerticallyToAdjacentLineIntent>(context),
+    SelectAllTextIntent: makeAction<SelectAllTextIntent>(context),
+    PasteTextIntent: makeAction<PasteTextIntent>(context),
+    RedoTextIntent: makeAction<RedoTextIntent>(context),
+    UndoTextIntent: makeAction<UndoTextIntent>(context),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    if (!Platform.isMacOS) {
+      return widget.child;
+    }
+    return Actions(
+      actions: _actions,
+      child: widget.child,
+    );
+  }
+}
+
+Action<T> makeAction<T extends Intent>(BuildContext context) =>
+    Action<T>.overridable(
+      defaultAction: _CallbackContextAction(),
+      context: context,
+    );
+
+class _CallbackContextAction<T extends Intent> extends ContextAction<T> {
+  _CallbackContextAction();
+
+  bool? _consumeKey;
+
+  @override
+  bool consumesKey(T intent) {
+    final consumeKey = _consumeKey;
+    _consumeKey = null;
+    if (consumeKey != null) {
+      return consumeKey;
+    }
+    return callingAction?.consumesKey(intent) ?? true;
+  }
+
+  @override
+  Object? invoke(T intent, [BuildContext? context]) {
+    if (context == null) {
+      e('No context provided to _CallbackContextAction');
+      return callingAction?.invoke(intent);
+    }
+    final state = context.findAncestorStateOfType<EditableTextState>();
+    if (state == null) {
+      e('failed to find EditableTextState');
+      return callingAction?.invoke(intent);
+    }
+
+    final composingRange = state.textEditingValue.composing;
+
+    if (composingRange.isValid && !composingRange.isCollapsed) {
+      _consumeKey = false;
+      return null;
+    }
+    return callingAction?.invoke(intent);
+  }
+}


### PR DESCRIPTION
reland #535 which revoked in #559


Remove this if https://github.com/flutter/flutter/issues/111113 has been fixed.