### PR TITLE
[linux] fix window show didn't work on wayland

### DIFF
--- a/lib/utils/local_notification_center.dart
+++ b/lib/utils/local_notification_center.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:bring_window_to_front/bring_window_to_front.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
@@ -139,6 +140,10 @@ class _LocalNotificationManager extends _NotificationManager {
             (element.notification as Tuple2<Uri, int>).item1 == uri,
         orElse: () => null);
     if (notification != null) notifications.remove(notification);
+
+    if (Platform.isLinux) {
+      unawaited(bringWindowToFront());
+    }
 
     onNotificationSelected(uri);
   }

--- a/lib/widgets/protocol_handler.dart
+++ b/lib/widgets/protocol_handler.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:bring_window_to_front/bring_window_to_front.dart';
 import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -57,9 +58,8 @@ class _LinuxAppProtocolHandler extends HookWidget {
     useEffect(() {
       final object = _MixinDbusObject(
         open: (url) {
-          windowManager
-            ..show()
-            ..focus();
+          windowManager.show();
+          bringWindowToFront();
           if (url != null) {
             openUri(context, url);
           }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <bring_window_to_front/bring_window_to_front_plugin.h>
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <desktop_lifecycle/desktop_lifecycle_plugin.h>
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
@@ -19,6 +20,9 @@
 #include <window_size/window_size_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) bring_window_to_front_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "BringWindowToFrontPlugin");
+  bring_window_to_front_plugin_register_with_registrar(bring_window_to_front_registrar);
   g_autoptr(FlPluginRegistrar) desktop_drop_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopDropPlugin");
   desktop_drop_plugin_register_with_registrar(desktop_drop_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  bring_window_to_front
   desktop_drop
   desktop_lifecycle
   desktop_webview_window

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  bring_window_to_front:
+    dependency: "direct main"
+    description:
+      path: "packages/bring_window_to_front"
+      ref: "904786942d698d103ef1f27b5e9331c6a6ec8a37"
+      resolved-ref: "904786942d698d103ef1f27b5e9331c6a6ec8a37"
+      url: "https://github.com/MixinNetwork/flutter-plugins.git"
+    source: git
+    version: "0.0.1"
   build:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,11 @@ dependencies:
   async: ^2.8.1
   bloc: ^8.1.0
   blurhash_dart: ^1.0.2
+  bring_window_to_front:
+    git:
+      url: https://github.com/MixinNetwork/flutter-plugins.git
+      ref: 904786942d698d103ef1f27b5e9331c6a6ec8a37
+      path: packages/bring_window_to_front
   dbus: ^0.7.8
   decimal: ^2.3.0
   desktop_drop: ^0.4.0


### PR DESCRIPTION
fix window did't bring to front when click a notification or an external url

----

On wayland, if gtk window was covered by other window, it will not be brought to front by call `gtk_window_present`.

see more: https://gitlab.gnome.org/GNOME/gtk/-/issues/624