### PR TITLE
log useFuture/useStream snapshot errors

### DIFF
--- a/lib/db/dao/conversation_dao.dart
+++ b/lib/db/dao/conversation_dao.dart
@@ -37,11 +37,9 @@ class ConversationDao extends DatabaseAccessor<MixinDatabase>
         db.conversations,
         db.users,
       ]))
-      .asyncMap((event) => allUnseenIgnoreMuteMessageCount().getSingle())
-      .where((event) => event != null)
-      .map((event) => event!);
+      .asyncMap((event) => allUnseenIgnoreMuteMessageCount().getSingle());
 
-  Selectable<int?> allUnseenIgnoreMuteMessageCount() =>
+  Selectable<int> allUnseenIgnoreMuteMessageCount() =>
       db.baseUnseenMessageCount(
         (conversation, owner, __) {
           final now = const MillisDateConverter().toSql(DateTime.now());

--- a/lib/db/mixin_database.g.dart
+++ b/lib/db/mixin_database.g.dart
@@ -14372,7 +14372,7 @@ abstract class _$MixinDatabase extends GeneratedDatabase {
         startIndex: $arrayStartIndex);
     $arrayStartIndex += generatedwhere.amountOfVariables;
     return customSelect(
-        'SELECT COUNT(1) AS unseen_conversation_count, SUM(CASE WHEN(CASE WHEN conversation.category = \'GROUP\' THEN conversation.mute_until ELSE owner.mute_until END)>=(strftime(\'%s\', \'now\') * 1000)AND IFNULL(conversation.unseen_message_count, 0) > 0 THEN 1 ELSE 0 END) AS unseen_muted_conversation_count FROM conversations AS conversation INNER JOIN users AS owner ON owner.user_id = conversation.owner_id WHERE ${generatedwhere.sql} LIMIT 1',
+        'SELECT COUNT(1) AS unseen_conversation_count, IFNULL(SUM(CASE WHEN(CASE WHEN conversation.category = \'GROUP\' THEN conversation.mute_until ELSE owner.mute_until END)>=(strftime(\'%s\', \'now\') * 1000)AND IFNULL(conversation.unseen_message_count, 0) > 0 THEN 1 ELSE 0 END), 0) AS unseen_muted_conversation_count FROM conversations AS conversation INNER JOIN users AS owner ON owner.user_id = conversation.owner_id WHERE ${generatedwhere.sql} LIMIT 1',
         variables: [
           ...generatedwhere.introducedVariables
         ],

--- a/lib/db/mixin_database.g.dart
+++ b/lib/db/mixin_database.g.dart
@@ -12740,7 +12740,7 @@ abstract class _$MixinDatabase extends GeneratedDatabase {
 
   Selectable<ConversationCircleItem> allCircles() {
     return customSelect(
-        'SELECT ci.circle_id, ci.name, ci.created_at, ci.ordered_at, COUNT(c.conversation_id) AS count, SUM(CASE WHEN IFNULL(c.unseen_message_count, 0) > 0 THEN 1 ELSE 0 END) AS unseen_conversation_count, SUM(CASE WHEN(CASE WHEN c.category = \'GROUP\' THEN c.mute_until ELSE owner.mute_until END)>=(strftime(\'%s\', \'now\') * 1000)AND IFNULL(c.unseen_message_count, 0) > 0 THEN 1 ELSE 0 END) AS unseen_muted_conversation_count FROM circles AS ci LEFT JOIN circle_conversations AS cc ON ci.circle_id = cc.circle_id LEFT JOIN conversations AS c ON c.conversation_id = cc.conversation_id LEFT JOIN users AS owner ON owner.user_id = c.owner_id GROUP BY ci.circle_id ORDER BY ci.ordered_at ASC, ci.created_at ASC',
+        'SELECT ci.circle_id, ci.name, ci.created_at, ci.ordered_at, COUNT(c.conversation_id) AS count, IFNULL(SUM(CASE WHEN IFNULL(c.unseen_message_count, 0) > 0 THEN 1 ELSE 0 END), 0) AS unseen_conversation_count, IFNULL(SUM(CASE WHEN(CASE WHEN c.category = \'GROUP\' THEN c.mute_until ELSE owner.mute_until END)>=(strftime(\'%s\', \'now\') * 1000)AND IFNULL(c.unseen_message_count, 0) > 0 THEN 1 ELSE 0 END), 0) AS unseen_muted_conversation_count FROM circles AS ci LEFT JOIN circle_conversations AS cc ON ci.circle_id = cc.circle_id LEFT JOIN conversations AS c ON c.conversation_id = cc.conversation_id LEFT JOIN users AS owner ON owner.user_id = c.owner_id GROUP BY ci.circle_id ORDER BY ci.ordered_at ASC, ci.created_at ASC',
         variables: [],
         readsFrom: {
           circles,
@@ -14339,7 +14339,7 @@ abstract class _$MixinDatabase extends GeneratedDatabase {
     });
   }
 
-  Selectable<int?> baseUnseenMessageCount(BaseUnseenMessageCount$where where) {
+  Selectable<int> baseUnseenMessageCount(BaseUnseenMessageCount$where where) {
     var $arrayStartIndex = 1;
     final generatedwhere = $write(
         where(
@@ -14350,7 +14350,7 @@ abstract class _$MixinDatabase extends GeneratedDatabase {
         startIndex: $arrayStartIndex);
     $arrayStartIndex += generatedwhere.amountOfVariables;
     return customSelect(
-        'SELECT SUM(unseen_message_count) AS _c0 FROM conversations AS conversation INNER JOIN users AS owner ON owner.user_id = conversation.owner_id LEFT JOIN circle_conversations AS circleConversation ON conversation.conversation_id = circleConversation.conversation_id WHERE ${generatedwhere.sql} LIMIT 1',
+        'SELECT IFNULL(SUM(unseen_message_count), 0) AS _c0 FROM conversations AS conversation INNER JOIN users AS owner ON owner.user_id = conversation.owner_id LEFT JOIN circle_conversations AS circleConversation ON conversation.conversation_id = circleConversation.conversation_id WHERE ${generatedwhere.sql} LIMIT 1',
         variables: [
           ...generatedwhere.introducedVariables
         ],
@@ -14359,7 +14359,7 @@ abstract class _$MixinDatabase extends GeneratedDatabase {
           users,
           circleConversations,
           ...generatedwhere.watchedTables,
-        }).map((QueryRow row) => row.readNullable<int>('_c0'));
+        }).map((QueryRow row) => row.read<int>('_c0'));
   }
 
   Selectable<BaseUnseenConversationCountResult> baseUnseenConversationCount(

--- a/lib/db/moor/dao/circle.drift
+++ b/lib/db/moor/dao/circle.drift
@@ -1,19 +1,42 @@
 import '../mixin.drift';
 
 allCircles AS ConversationCircleItem:
-SELECT
-ci.circle_id,
- ci.name,
- ci.created_at,
- ci.ordered_at,
- COUNT(c.conversation_id) AS count,
- SUM(CASE WHEN IFNULL(c.unseen_message_count, 0) > 0 THEN 1 ELSE 0 END) AS unseen_conversation_count,
- SUM(CASE WHEN (CASE WHEN c.category = 'GROUP' THEN c.mute_until ELSE owner.mute_until END) >= (strftime('%s', 'now') * 1000) AND IFNULL(c.unseen_message_count, 0) > 0 THEN 1 ELSE 0 END) AS unseen_muted_conversation_count
-        FROM circles ci
-        LEFT JOIN circle_conversations cc ON ci.circle_id = cc.circle_id
-        LEFT JOIN conversations c ON c.conversation_id = cc.conversation_id
-        LEFT JOIN users owner ON owner.user_id = c.owner_id
-        GROUP BY ci.circle_id ORDER BY ci.ordered_at ASC, ci.created_at ASC;
+SELECT ci.circle_id,
+    ci.name,
+    ci.created_at,
+    ci.ordered_at,
+    COUNT(c.conversation_id) AS count,
+    IFNULL(
+        SUM(
+            CASE
+                WHEN IFNULL(c.unseen_message_count, 0) > 0 THEN 1
+                ELSE 0
+            END
+        ),
+        0
+    ) AS unseen_conversation_count,
+    IFNULL(
+        SUM(
+            CASE
+                WHEN (
+                    CASE
+                        WHEN c.category = 'GROUP' THEN c.mute_until
+                        ELSE owner.mute_until
+                    END
+                ) >= (strftime('%s', 'now') * 1000)
+                AND IFNULL(c.unseen_message_count, 0) > 0 THEN 1
+                ELSE 0
+            END
+        ),
+        0
+    ) AS unseen_muted_conversation_count
+FROM circles ci
+    LEFT JOIN circle_conversations cc ON ci.circle_id = cc.circle_id
+    LEFT JOIN conversations c ON c.conversation_id = cc.conversation_id
+    LEFT JOIN users owner ON owner.user_id = c.owner_id
+GROUP BY ci.circle_id
+ORDER BY ci.ordered_at ASC,
+    ci.created_at ASC;
 
 circleByConversationId AS ConversationCircleManagerItem:
 SELECT ci.circle_id, ci.name, COUNT(c.conversation_id) AS count FROM circles ci LEFT JOIN circle_conversations cc ON ci.circle_id = cc.circle_id

--- a/lib/db/moor/dao/conversation.drift
+++ b/lib/db/moor/dao/conversation.drift
@@ -87,11 +87,24 @@ WHERE $where
 LIMIT 1;
 
 baseUnseenConversationCount:
-SELECT
-  COUNT(1) unseen_conversation_count,
-  SUM(CASE WHEN (CASE WHEN conversation.category = 'GROUP' THEN conversation.mute_until ELSE owner.mute_until END) >= (strftime('%s', 'now') * 1000) AND IFNULL(conversation.unseen_message_count, 0) > 0 THEN 1 ELSE 0 END) AS unseen_muted_conversation_count
-  FROM conversations conversation
-  INNER JOIN users owner ON owner.user_id = conversation.owner_id
+SELECT COUNT(1) AS unseen_conversation_count,
+    IFNULL(
+        SUM(
+            CASE
+                WHEN(
+                    CASE
+                        WHEN conversation.category = 'GROUP' THEN conversation.mute_until
+                        ELSE owner.mute_until
+                    END
+                ) >=(strftime('%s', 'now') * 1000)
+                AND IFNULL(conversation.unseen_message_count, 0) > 0 THEN 1
+                ELSE 0
+            END
+        ),
+        0
+    ) AS unseen_muted_conversation_count
+FROM conversations AS conversation
+    INNER JOIN users AS owner ON owner.user_id = conversation.owner_id
 WHERE $where
 LIMIT 1;
 

--- a/lib/db/moor/dao/conversation.drift
+++ b/lib/db/moor/dao/conversation.drift
@@ -80,9 +80,10 @@ LIMIT $limit;
 
 
 baseUnseenMessageCount:
-SELECT SUM(unseen_message_count) FROM conversations conversation
-  INNER JOIN users owner ON owner.user_id = conversation.owner_id
-  LEFT JOIN circle_conversations circleConversation ON conversation.conversation_id = circleConversation.conversation_id
+SELECT IFNULL(SUM(unseen_message_count), 0)
+FROM conversations conversation
+    INNER JOIN users owner ON owner.user_id = conversation.owner_id
+    LEFT JOIN circle_conversations circleConversation ON conversation.conversation_id = circleConversation.conversation_id
 WHERE $where
 LIMIT 1;
 

--- a/lib/ui/home/bloc/conversation_list_bloc.dart
+++ b/lib/ui/home/bloc/conversation_list_bloc.dart
@@ -95,16 +95,16 @@ class ConversationListBloc extends Cubit<PagingState<ConversationItem>>
   }
 
   Future<void> _initBadge() async {
-    Future<void> updateBadge(int? count) async {
+    Future<void> updateBadge(int count) async {
       if (!kPlatformIsDarwin) {
         // not work on other platform.
         return;
       }
-      if ((count ?? 0) == 0) {
+      if (count == 0) {
         await FlutterAppIconBadge.removeBadge();
         return;
       }
-      await FlutterAppIconBadge.updateBadge(count!);
+      await FlutterAppIconBadge.updateBadge(count);
     }
 
     final count = await database.conversationDao

--- a/lib/ui/home/chat/chat_page.dart
+++ b/lib/ui/home/chat/chat_page.dart
@@ -927,13 +927,11 @@ class _JumpMentionButton extends HookWidget {
       converter: (state) => state?.conversationId,
       when: (conversationId) => conversationId != null,
     )!;
-    final messageMentions = useStream(
-          useMemoized(
-              () => context.database.messageMentionDao
-                  .unreadMentionMessageByConversationId(conversationId)
-                  .watchThrottle(kSlowThrottleDuration),
-              [conversationId]),
-        ).data ??
+    final messageMentions = useMemoizedStream(
+            () => context.database.messageMentionDao
+                .unreadMentionMessageByConversationId(conversationId)
+                .watchThrottle(kSlowThrottleDuration),
+            keys: [conversationId]).data ??
         [];
 
     if (messageMentions.isEmpty) return const SizedBox();

--- a/lib/ui/home/chat/input_container.dart
+++ b/lib/ui/home/chat/input_container.dart
@@ -426,19 +426,18 @@ class _SendTextField extends HookWidget {
     final mentionCubit = context.read<MentionCubit>();
     final mentionStream = mentionCubit.stream;
 
-    final sendable = useStream(
-          useMemoized(
-              () => Rx.combineLatest2<TextEditingValue, MentionState, bool>(
-                  textEditingValueStream,
-                  mentionStream.startWith(mentionCubit.state),
-                  (textEditingValue, mentionState) =>
-                      (textEditingValue.text.trim().isNotEmpty) &&
-                      (textEditingValue.composing.composed) &&
-                      mentionState.users.isEmpty).distinct(),
-              [
-                textEditingValueStream,
-                mentionStream,
-              ]),
+    final sendable = useMemoizedStream(
+          () => Rx.combineLatest2<TextEditingValue, MentionState, bool>(
+              textEditingValueStream,
+              mentionStream.startWith(mentionCubit.state),
+              (textEditingValue, mentionState) =>
+                  (textEditingValue.text.trim().isNotEmpty) &&
+                  (textEditingValue.composing.composed) &&
+                  mentionState.users.isEmpty).distinct(),
+          keys: [
+            textEditingValueStream,
+            mentionStream,
+          ],
         ).data ??
         true;
 

--- a/lib/ui/home/chat_slide_page/chat_info_page.dart
+++ b/lib/ui/home/chat_slide_page/chat_info_page.dart
@@ -55,10 +55,11 @@ class ChatInfoPage extends HookWidget {
       accountServer.refreshUsers([userId], force: true);
     }, [userId]);
 
-    final announcement = useStream<String?>(
-      useMemoized(() => context.database.conversationDao
+    final announcement = useMemoizedStream<String?>(
+      () => context.database.conversationDao
           .announcement(conversationId)
-          .watchSingleThrottle(kVerySlowThrottleDuration)),
+          .watchSingleThrottle(kVerySlowThrottleDuration),
+      keys: [conversationId],
     ).data;
     if (!conversation.isLoaded) return const SizedBox();
 

--- a/lib/ui/home/chat_slide_page/circle_manager_page.dart
+++ b/lib/ui/home/chat_slide_page/circle_manager_page.dart
@@ -8,6 +8,7 @@ import '../../../db/mixin_database.dart';
 
 import '../../../utils/color_utils.dart';
 import '../../../utils/extension/extension.dart';
+import '../../../utils/hook.dart';
 import '../../../widgets/action_button.dart';
 import '../../../widgets/app_bar.dart';
 import '../../../widgets/dialog.dart';
@@ -26,23 +27,19 @@ class CircleManagerPage extends HookWidget {
       return conversationId;
     })!;
 
-    final circles = useStream<List<ConversationCircleManagerItem>>(
-          useMemoized(
-            () => context.database.circleDao
-                .circleByConversationId(conversationId)
-                .watchThrottle(kDefaultThrottleDuration),
-            [conversationId],
-          ),
+    final circles = useMemoizedStream<List<ConversationCircleManagerItem>>(
+          () => context.database.circleDao
+              .circleByConversationId(conversationId)
+              .watchThrottle(kDefaultThrottleDuration),
+          keys: [conversationId],
           initialData: [],
         ).data ??
         [];
-    final otherCircles = useStream<List<ConversationCircleManagerItem>>(
-          useMemoized(
-            () => context.database.circleDao
-                .otherCircleByConversationId(conversationId)
-                .watchThrottle(kDefaultThrottleDuration),
-            [conversationId],
-          ),
+    final otherCircles = useMemoizedStream<List<ConversationCircleManagerItem>>(
+          () => context.database.circleDao
+              .otherCircleByConversationId(conversationId)
+              .watchThrottle(kDefaultThrottleDuration),
+          keys: [conversationId],
           initialData: [],
         ).data ??
         [];

--- a/lib/ui/home/chat_slide_page/group_invite/group_invite_dialog.dart
+++ b/lib/ui/home/chat_slide_page/group_invite/group_invite_dialog.dart
@@ -6,6 +6,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import '../../../../constants/resources.dart';
 import '../../../../db/mixin_database.dart';
 import '../../../../utils/extension/extension.dart';
+import '../../../../utils/hook.dart';
 import '../../../../widgets/avatar_view/avatar_view.dart';
 import '../../../../widgets/buttons.dart';
 import '../../../../widgets/dialog.dart';
@@ -31,13 +32,14 @@ class _GroupInviteByLinkDialog extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final conversation = useStream(
-      useMemoized(() {
+    final conversation = useMemoizedStream(
+      () {
         context.accountServer.refreshConversation(conversationId);
         return context.database.conversationDao
             .conversationById(conversationId)
             .watchSingleOrNullThrottle(kDefaultThrottleDuration);
-      }, [conversationId]),
+      },
+      keys: [conversationId],
     ).data;
     return Material(
         color: context.theme.popUp,

--- a/lib/ui/home/chat_slide_page/group_participants_page.dart
+++ b/lib/ui/home/chat_slide_page/group_participants_page.dart
@@ -6,6 +6,7 @@ import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
 import '../../../constants/resources.dart';
 import '../../../db/mixin_database.dart';
 import '../../../utils/extension/extension.dart';
+import '../../../utils/hook.dart';
 import '../../../widgets/action_button.dart';
 import '../../../widgets/app_bar.dart';
 import '../../../widgets/avatar_view/avatar_view.dart';
@@ -32,12 +33,12 @@ class GroupParticipantsPage extends HookWidget {
       return conversationId!;
     });
 
-    final participants = useStream(useMemoized(() {
+    final participants = useMemoizedStream(() {
           final dao = context.database.participantDao;
           return dao
               .groupParticipantsByConversationId(conversationId)
               .watchThrottle(kSlowThrottleDuration);
-        }, [conversationId])).data ??
+        }, keys: [conversationId]).data ??
         const <ParticipantUser>[];
 
     // Find current user info to check if we have group manage permission.

--- a/lib/ui/setting/storage_usage_detail_page.dart
+++ b/lib/ui/setting/storage_usage_detail_page.dart
@@ -27,9 +27,9 @@ class StorageUsageDetailPage extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final watchEvent = useStream(
-      useMemoized(() => File(context.accountServer.getMediaFilePath())
-          .watch(recursive: true)),
+    final watchEvent = useMemoizedStream(
+      () =>
+          File(context.accountServer.getMediaFilePath()).watch(recursive: true),
       initialData: null,
     ).data;
 

--- a/lib/utils/hook.dart
+++ b/lib/utils/hook.dart
@@ -10,29 +10,40 @@ import 'package:tuple/tuple.dart';
 
 import '../app.dart';
 import 'app_lifecycle.dart';
+import 'logger.dart';
 
 AsyncSnapshot<T> useMemoizedFuture<T>(
   Future<T> Function() futureBuilder,
   T initialData, {
   List<Object?> keys = const <Object>[],
 }) =>
-    useFuture(
+    _logSnapshotError(useFuture(
       useMemoized(
         futureBuilder,
         keys,
       ),
       initialData: initialData,
-    );
+    ));
 
 AsyncSnapshot<T> useMemoizedStream<T>(
   Stream<T> Function() valueBuilder, {
   T? initialData,
   List<Object?> keys = const <Object>[],
 }) =>
-    useStream<T>(
+    _logSnapshotError(useStream<T>(
       useMemoized<Stream<T>>(valueBuilder, keys),
       initialData: initialData,
-    );
+    ));
+
+AsyncSnapshot<T> _logSnapshotError<T>(AsyncSnapshot<T> snapshot) {
+  useEffect(() {
+    if (snapshot.hasError) {
+      e('error: ${snapshot.error} ${snapshot.stackTrace}'
+          '\n call stack: \n ${StackTrace.current}');
+    }
+  }, [snapshot]);
+  return snapshot;
+}
 
 T useBloc<T extends BlocBase>(
   T Function() valueBuilder, {

--- a/lib/widgets/avatar_view/avatar_view.dart
+++ b/lib/widgets/avatar_view/avatar_view.dart
@@ -7,6 +7,7 @@ import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart' hide User;
 import '../../db/mixin_database.dart';
 import '../../utils/color_utils.dart';
 import '../../utils/extension/extension.dart';
+import '../../utils/hook.dart';
 import '../cache_image.dart';
 
 class ConversationAvatarWidget extends HookWidget {
@@ -43,24 +44,22 @@ class ConversationAvatarWidget extends HookWidget {
 
     final _userId = conversation?.ownerId ?? userId;
 
-    final list = useStream(
-          useMemoized(
-            () {
-              if (_category == ConversationCategory.group) {
-                return context.database.participantDao
-                    .participantsAvatar(_conversationId!)
-                    .watchThrottle(const Duration(minutes: 6))
-                    .map((event) => _category == ConversationCategory.contact
-                        ? event
-                            .where((element) =>
-                                element.relationship != UserRelationship.me)
-                            .toList()
-                        : event);
-              }
-              return const Stream<List<User>>.empty();
-            },
-            [_conversationId, _category],
-          ),
+    final list = useMemoizedStream(
+          () {
+            if (_category == ConversationCategory.group) {
+              return context.database.participantDao
+                  .participantsAvatar(_conversationId!)
+                  .watchThrottle(const Duration(minutes: 6))
+                  .map((event) => _category == ConversationCategory.contact
+                      ? event
+                          .where((element) =>
+                              element.relationship != UserRelationship.me)
+                          .toList()
+                      : event);
+            }
+            return const Stream<List<User>>.empty();
+          },
+          keys: [_conversationId, _category],
           initialData: <User>[],
         ).data ??
         <User>[];

--- a/lib/widgets/user/user_dialog.dart
+++ b/lib/widgets/user/user_dialog.dart
@@ -6,6 +6,7 @@ import '../../db/mixin_database.dart';
 import '../../ui/home/bloc/conversation_cubit.dart';
 import '../../ui/home/chat/chat_page.dart';
 import '../../utils/extension/extension.dart';
+import '../../utils/hook.dart';
 import '../action_button.dart';
 import '../avatar_view/avatar_view.dart';
 import '../buttons.dart';
@@ -116,11 +117,11 @@ class _UserProfileLoader extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final accountServer = context.accountServer;
-    final user = useStream(useMemoized(
+    final user = useMemoizedStream(
         () => accountServer.database.userDao
             .userById(userId)
             .watchSingleOrNullThrottle(kDefaultThrottleDuration),
-        [userId])).data;
+        keys: [userId]).data;
 
     useEffect(() {
       if (refreshUser) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -843,10 +843,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "323b7c70073cccf6b9b8d8b334be418a3293cfb612a560dc2737160a37bf61bd"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.6"
+    version: "0.6.5"
   json_annotation:
     dependency: "direct main"
     description:
@@ -955,10 +955,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1085,10 +1085,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   path_drawing:
     dependency: transitive
     description:
@@ -1450,10 +1450,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.1"
   synchronized:
     dependency: transitive
     description:
@@ -1489,10 +1489,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: c9282698e2982b6c3817037554e52f99d4daba493e8028f8112a83d68ccd0b12
+      sha256: c9aba3b3dbfe8878845dfab5fa096eb8de7b62231baeeb1cea8e3ee81ca8c6d8
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.17"
+    version: "0.4.15"
   timezone:
     dependency: transitive
     description:
@@ -1800,5 +1800,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0-345.0.dev <4.0.0"
+  dart: ">=2.18.0 <4.0.0"
   flutter: ">=3.3.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -971,10 +971,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.14"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1101,10 +1101,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_drawing:
     dependency: transitive
     description:
@@ -1466,10 +1466,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   synchronized:
     dependency: transitive
     description:
@@ -1505,10 +1505,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: c9aba3b3dbfe8878845dfab5fa096eb8de7b62231baeeb1cea8e3ee81ca8c6d8
+      sha256: c9282698e2982b6c3817037554e52f99d4daba493e8028f8112a83d68ccd0b12
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.15"
+    version: "0.4.17"
   timezone:
     dependency: transitive
     description:
@@ -1816,5 +1816,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
+  dart: ">=2.19.0-0 <4.0.0"
   flutter: ">=3.3.0"


### PR DESCRIPTION
noticed that we use always use `useMemoziedFuture(xxx).data ?? emptyValue` in `Widget#build` function. it caused the error in snapshot has been ignored. such as #981

to avoid this, add a `_logSnapshotError` to print the snapshot's error  in `useMemoziedFuture` and `useMemoizedStream`.

And fix some bug of SQL