### PR TITLE
move _encodeBlurHash to main isolate

### DIFF
--- a/lib/utils/extension/src/file.dart
+++ b/lib/utils/extension/src/file.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:blurhash_dart/blurhash_dart.dart';
 import 'package:cross_file/cross_file.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:image/image.dart';
 import 'package:mime/mime.dart';
@@ -17,8 +16,7 @@ extension FileExtension on File {
         name: basename(path),
       );
 
-  Future<String?> encodeBlurHash() async =>
-      compute<String, String?>(_encodeBlurHash, path);
+  Future<String?> encodeBlurHash() async => _encodeBlurHash(path);
 }
 
 Future<String?> _encodeBlurHash(String path) async {


### PR DESCRIPTION
FileImage(File(path)).toImage() only works in main isolate

```
flutter: When the exception was thrown, this was the stack:
flutter: #0      BindingBase.checkInstance.<anonymous closure> (package:flutter/src/foundation/binding.dart:287:9)
flutter: #1      BindingBase.checkInstance (package:flutter/src/foundation/binding.dart:369:6)
flutter: #2      PaintingBinding.instance (package:flutter/src/painting/binding.dart:31:54)
flutter: #3      ImageProvider.resolveStreamForKey (package:flutter/src/painting/image_provider.dart:511:61)
flutter: #4      ImageProvider.resolve.<anonymous closure> (package:flutter/src/painting/image_provider.dart:358:9)
flutter: #5      ImageProvider._createErrorHandlerAndKey.<anonymous closure> (package:flutter/src/painting/image_provider.dart:473:24)
flutter: #6      SynchronousFuture.then (package:flutter/src/foundation/synchronous_future.dart:41:39)
flutter: #7      ImageProvider._createErrorHandlerAndKey (package:flutter/src/painting/image_provider.dart:470:9)
flutter: #8      ImageProvider.resolve (package:flutter/src/painting/image_provider.dart:355:5)
flutter: #9      ImageProviderExtension.toImage (package:flutter_app/utils/extension/src/image.dart:9:20)
flutter: #10     _encodeBlurHash (package:flutter_app/utils/extension/src/file.dart:26:33)
flutter: #11     compute.<anonymous closure> (package:flutter/src/foundation/_isolates_io.dart:19:20)
flutter: #12     _RemoteRunner._run (dart:isolate:960:47)
flutter: #13     _RemoteRunner._remoteExecute (dart:isolate:954:12)
flutter: #14     _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:300:17)
flutter: #15     _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:192:26)
```