### PR TITLE
Improve frame rate of sticker

### DIFF
--- a/lib/widgets/sticker_page/sticker_item.dart
+++ b/lib/widgets/sticker_page/sticker_item.dart
@@ -71,6 +71,7 @@ class StickerItem extends HookWidget {
             height: height,
             width: width,
             fit: BoxFit.contain,
+            frameRate: FrameRate(50),
             onLoaded: (composition) {
               controller.duration = composition.duration;
               listener();


### PR DESCRIPTION
Set lottie stickers with a maximum frame rate of 50, consistent with GIF