### PR TITLE
Fix msix version info

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -188,7 +188,7 @@ jobs:
           $version=$version_str.Split("+")[0]
           $build_number=$version_str.Split("+")[1]
           flutter build windows --dart-define="APP_VERSION=$version" --dart-define="APP_BUILD_NUMBER=$build_number"
-          echo "MSIX_PACKAGE_VERSION=$version.$build_number" >> $GITHUB_OUTPUT
+          echo "MSIX_PACKAGE_VERSION=$version.$build_number" >> $Env:GITHUB_OUTPUT
 
       - name: Build Installer
         run: |

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -182,11 +182,13 @@ jobs:
         run: flutter test
 
       - name: Build APP
+        id: build-app
         run: |
           $version_str=$(gc .\pubspec.yaml | select-string '(?<=^version: ).*' -AllMatches | Select-Object -Expand Matches | %{$_.Value})
           $version=$version_str.Split("+")[0]
           $build_number=$version_str.Split("+")[1]
           flutter build windows --dart-define="APP_VERSION=$version" --dart-define="APP_BUILD_NUMBER=$build_number"
+          echo "MSIX_PACKAGE_VERSION=$version.$build_number" >> $GITHUB_OUTPUT
 
       - name: Build Installer
         run: |
@@ -200,7 +202,9 @@ jobs:
           path: build\mixin_setup.exe
 
       - name: Build msix
-        run: flutter pub run msix:create
+        run: |
+          echo "create msix. version: ${{ steps.build-app.outputs.MSIX_PACKAGE_VERSION }}"
+          flutter pub run msix:create --build-windows false --version ${{ steps.build-app.outputs.MSIX_PACKAGE_VERSION }}
 
       - name: Upload msix
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
1. auto use `$version.$build_number` as msix package version
2. fix msix:create overrided version and build number dart define. add `--build-windows false` to dsiable msix auto build.