### PR TITLE
fix get device id on linux

### DIFF
--- a/lib/utils/platform.dart
+++ b/lib/utils/platform.dart
@@ -51,13 +51,15 @@ Future<String> getDeviceId() async {
       id = (await _getWindowsDeviceId())?.trim();
     } else if (Platform.isMacOS) {
       id = (await _getMacOSDeviceId())?.trim();
+    } else if (Platform.isLinux) {
+      id = (await _getLinuxDeviceId())?.trim();
     } else {
       id = (await PlatformDeviceId.getDeviceId)?.trim();
     }
     if (id == null || id.isEmpty) {
       throw Exception("${Platform.operatingSystem}'s device id is empty");
     }
-    if (Platform.isAndroid || kIsWeb) {
+    if (Platform.isAndroid || kIsWeb || Platform.isLinux) {
       return nameUuidFromBytes(utf8.encode(id)).uuid;
     }
 
@@ -66,6 +68,29 @@ Future<String> getDeviceId() async {
     e('failed to get device id. $error $stack');
   }
   return 'unknown';
+}
+
+// https://man7.org/linux/man-pages/man5/machine-id.5.html
+Future<String?> _getLinuxDeviceId() async {
+  final process = await Process.run(
+    'cat',
+    ['/etc/machine-id'],
+  );
+
+  if (process.stdout == null) {
+    e('failed to get linux device id. ${process.stderr}');
+    return null;
+  }
+
+  final machineId = process.stdout.toString().trim();
+
+  // Check machineId is valid.
+  // the machineId should be hexademical 32-characters, lowercase.
+  if (machineId.length != 32) {
+    e('failed to get linux device id. machineId length is not 32. $machineId');
+    return null;
+  }
+  return machineId;
 }
 
 // ref: https://github.com/BestBurning/platform_device_id/issues/15#issuecomment-1064081170


### PR DESCRIPTION
replace with  `/etc/matchine-id` instead. ref: https://man7.org/linux/man-pages/man5/machine-id.5.html

fix error: 
```
failed to get device id. Exception: linux's device id is empty 
/sys/firmware/dmi/tables/smbios_entry_point: Permission denied
```