### PR TITLE
Skip database_fts5_search_test.dart on Windows

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -180,7 +180,6 @@ jobs:
 
       - name: Run tests
         run: flutter test
-        shell: cmd
 
       - name: Build APP
         id: build-app

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -180,6 +180,7 @@ jobs:
 
       - name: Run tests
         run: flutter test
+        shell: cmd
 
       - name: Build APP
         id: build-app

--- a/test/db/database_fts5_search_test.dart
+++ b/test/db/database_fts5_search_test.dart
@@ -1,3 +1,4 @@
+@TestOn('linux || mac-os')
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_app/db/fts_database.dart';


### PR DESCRIPTION
only run database test on Linux or macOS since no sqlite3 library in Windows test env.