### PR TITLE
fix text message keyword not escaped

### DIFF
--- a/lib/widgets/message/item/text/text_message.dart
+++ b/lib/widgets/message/item/text/text_message.dart
@@ -109,7 +109,7 @@ class TextMessage extends HookWidget {
                 ...botNumberHighlightTextSpans
               ].fold<Set<HighlightTextSpan>>({}, (previousValue, element) {
                 element.text.splitMapJoin(
-                  RegExp(keyword, caseSensitive: false),
+                  RegExp(RegExp.escape(keyword), caseSensitive: false),
                   onMatch: (match) {
                     previousValue.add(
                       HighlightTextSpan(


### PR DESCRIPTION
fix error:
```log
[E] FlutterError: FormatException: Nothing to repeatgithub++.com #0      new _RegExp (dart:core-patch/regexp_patch.dart:218:28)
#1      new RegExp (dart:core-patch/regexp_patch.dart:27:15)
#2      TextMessage.build.<anonymous closure>.<anonymous closure> (package:flutter_app/widgets/message/item/text/text_message.dart:112:19)
#3      ListMixin.fold (dart:collection/list.dart:237:22)
```