### PR TITLE
improve play audio message in transcript/pin list

### DIFF
--- a/lib/widgets/message/item/audio_message.dart
+++ b/lib/widgets/message/item/audio_message.dart
@@ -192,9 +192,9 @@ class _AnimatedWave extends HookWidget {
 
 class AudioMessagesPlayAgent {
   AudioMessagesPlayAgent(
-    this._list,
+    List<MessageItem> list,
     this.convertMessageAbsolutePath,
-  );
+  ) : _list = list.where((e) => e.type.isAudio).toList();
 
   final List<MessageItem> _list;
   final String Function(MessageItem? messageItem) convertMessageAbsolutePath;


### PR DESCRIPTION
fix play audio messages in transcript/pin page didn't filter audio type