### PR TITLE
refactor: Refactor file sending workflow in chat.

### DIFF
--- a/lib/ui/home/chat/files_preview.dart
+++ b/lib/ui/home/chat/files_preview.dart
@@ -128,6 +128,29 @@ class _FilesPreviewDialog extends HookWidget {
       showAsBigImage.value = hasImage && currentTab.value == _TabType.image;
     }, [hasImage, currentTab.value]);
 
+    Future<void> send() async {
+      if (currentTab.value != _TabType.zip) {
+        for (final file in files.value) {
+          unawaited(
+              _sendFile(context, file, quoteMessageCubit?.state?.messageId));
+        }
+        quoteMessageCubit?.emit(null);
+        Navigator.pop(context);
+      } else {
+        final zipFilePath = await runLoadBalancer(_archiveFiles, [
+          (await getTemporaryDirectory()).path,
+          ...files.value.map((e) => e.path),
+        ]);
+        unawaited(_sendFile(
+          context,
+          await _File.createFromPath(zipFilePath),
+          quoteMessageCubit?.state?.messageId,
+        ));
+        quoteMessageCubit?.emit(null);
+        Navigator.pop(context);
+      }
+    }
+
     return Material(
       child: Container(
           width: 480,
@@ -170,6 +193,7 @@ class _FilesPreviewDialog extends HookWidget {
                   const SizedBox(height: 4),
                   Expanded(
                     child: _FileInputOverlay(
+                      onSend: send,
                       onFileAdded: (fileAdded) {
                         final currentFiles =
                             files.value.map((e) => e.path).toSet();
@@ -216,29 +240,7 @@ class _FilesPreviewDialog extends HookWidget {
                   const SizedBox(height: 32),
                   Align(
                     child: ElevatedButton(
-                      onPressed: () async {
-                        if (currentTab.value != _TabType.zip) {
-                          for (final file in files.value) {
-                            unawaited(_sendFile(context, file,
-                                quoteMessageCubit?.state?.messageId));
-                          }
-                          quoteMessageCubit?.emit(null);
-                          Navigator.pop(context);
-                        } else {
-                          final zipFilePath =
-                              await runLoadBalancer(_archiveFiles, [
-                            (await getTemporaryDirectory()).path,
-                            ...files.value.map((e) => e.path),
-                          ]);
-                          unawaited(_sendFile(
-                            context,
-                            await _File.createFromPath(zipFilePath),
-                            quoteMessageCubit?.state?.messageId,
-                          ));
-                          quoteMessageCubit?.emit(null);
-                          Navigator.pop(context);
-                        }
-                      },
+                      onPressed: send,
                       style: ElevatedButton.styleFrom(
                         padding: const EdgeInsets.only(
                             left: 32, top: 18, bottom: 18, right: 32),
@@ -697,11 +699,13 @@ class _FileInputOverlay extends HookWidget {
   const _FileInputOverlay({
     required this.child,
     required this.onFileAdded,
+    required this.onSend,
   });
 
   final Widget child;
 
   final void Function(List<_File>) onFileAdded;
+  final void Function() onSend;
 
   @override
   Widget build(BuildContext context) {
@@ -714,12 +718,18 @@ class _FileInputOverlay extends HookWidget {
           meta: kPlatformIsDarwin,
           control: !kPlatformIsDarwin,
         ): const _PasteFileOrImageIntent(),
+        const SingleActivator(
+          LogicalKeyboardKey.enter,
+        ): const _SendFilesIntent(),
       },
       actions: {
         _PasteFileOrImageIntent: CallbackAction<Intent>(onInvoke: (_) async {
           final files = await getClipboardFiles();
           onFileAdded(await Future.wait(files.map(_File.createFromFile)));
-        })
+        }),
+        _SendFilesIntent: CallbackAction<Intent>(onInvoke: (_) {
+          onSend();
+        }),
       },
       child: DropTarget(
         onDragEntered: (_) => dragging.value = true,
@@ -750,6 +760,10 @@ class _FileInputOverlay extends HookWidget {
 
 class _PasteFileOrImageIntent extends Intent {
   const _PasteFileOrImageIntent();
+}
+
+class _SendFilesIntent extends Intent {
+  const _SendFilesIntent();
 }
 
 class _ChatDragIndicator extends StatelessWidget {


### PR DESCRIPTION
- Implement new `send` function in `_FilesPreviewDialog` to handle file sending
- Refactor code to remove duplicate send file logic
- Create `_SendFilesIntent` to invoke `onSend` function in `_FileInputOverlay`
- Add `onSend` callback to handle file sending in `_FileInputOverlay`
- Modify `ElevatedButton` `onPressed` to invoke `_SendFilesIntent` intent