### PR TITLE
Fix: Refactor message content handling in sending job

### DIFF
--- a/lib/workers/job/sending_job.dart
+++ b/lib/workers/job/sending_job.dart
@@ -160,6 +160,7 @@ class SendingJob extends JobQueue<Job> {
     if (message.category.isPost || message.category.isText) {
       content = content?.substring(0, min(content.length, kMaxTextLength));
       sentContent = content;
+      message = message.copyWith(content: content);
     } else if (message.category.isAttachment && content != null) {
       try {
         final attachment = AttachmentMessage.fromJson(
@@ -200,6 +201,7 @@ class SendingJob extends JobQueue<Job> {
     }
 
     Future<MessageResult> _sendPlainMessage(SendingMessage message) async {
+      var content = sentContent;
       if (message.category == MessageCategory.appCard ||
           message.category.isPost ||
           message.category.isTranscript ||


### PR DESCRIPTION
- Fix issues with `message` object in `sending_job.dart`
- Initialize `content` variable to avoid null reference errors
- Modify `content` field to prevent unexpected behavior
- Improve overall stability and reliability of the codebase