### PR TITLE
fix attachement transcript path

### DIFF
--- a/lib/utils/attachment/attachment_util.dart
+++ b/lib/utils/attachment/attachment_util.dart
@@ -55,7 +55,7 @@ abstract class _AttachmentJobBase {
 
 class AttachmentUtilBase {
   AttachmentUtilBase(this.mediaPath)
-      : transcriptPath = p.join(mediaPath, 'transcript') {
+      : transcriptPath = p.join(mediaPath, 'Transcripts') {
     Directory(transcriptPath).create(recursive: true);
   }
 


### PR DESCRIPTION
the transcript's attachments path should be `Transcripts`


https://github.com/MixinNetwork/flutter-app/pull/1122/files#diff-35b37dcc4663568f47550215842142deffe932fc19654ffe893ad4a1002eb8f7L73
