### PR TITLE
make device transfer user data biography which send out non-null

### DIFF
--- a/lib/utils/device_transfer/transfer_data_user.dart
+++ b/lib/utils/device_transfer/transfer_data_user.dart
@@ -41,7 +41,7 @@ class TransferDataUser {
         muteUntil: user.muteUntil,
         hasPin: user.hasPin == 1,
         appId: user.appId,
-        biography: user.biography,
+        biography: user.biography ?? '',
         isScam: user.isScam == 1,
         codeUrl: user.codeUrl,
         codeId: user.codeId,


### PR DESCRIPTION
when desktop as device transfer server, `User.biography` default to '' if is null.