### PR TITLE
skip device transfer test on Windows

### DIFF
--- a/test/utils/device_transfer_test.dart
+++ b/test/utils/device_transfer_test.dart
@@ -1,4 +1,5 @@
 @Timeout(Duration(minutes: 1))
+@TestOn('linux || mac-os')
 import 'dart:async';
 import 'dart:io';
 


### PR DESCRIPTION
the same as #1102.  no sqlite3 library in Windows test env.