### PR TITLE
fix: Fix conversation updating issue and import concurrency in paging bloc.

### DIFF
--- a/lib/bloc/paging/paging_bloc.dart
+++ b/lib/bloc/paging/paging_bloc.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:bloc/bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:tuple/tuple.dart';
@@ -102,9 +103,25 @@ abstract class PagingBloc<T> extends Bloc<PagingEvent, PagingState<T>>
     double alignment = 0,
     required PagingState<T> initState,
   }) : super(initState) {
-    on<PagingEvent>((event, emit) async {
-      await _onEvent(event, emit);
-    });
+    on<PagingUpdateEvent>(
+      (event, emit) async {
+        await _onEvent(event, emit);
+      },
+      transformer: restartable(),
+    );
+    on<PagingItemPositionEvent>(
+      (event, emit) async {
+        await _onEvent(event, emit);
+      },
+      transformer: restartable(),
+    );
+    on<PagingInitEvent>(
+      (event, emit) async {
+        await _onEvent(event, emit);
+      },
+      transformer: restartable(),
+    );
+
     itemPositionsListener.itemPositions.addListener(onItemPositions);
     add(PagingInitEvent(
       offset: offset,

--- a/lib/ui/home/bloc/conversation_list_bloc.dart
+++ b/lib/ui/home/bloc/conversation_list_bloc.dart
@@ -74,7 +74,7 @@ class ConversationListBloc extends Cubit<PagingState<ConversationItem>>
     DataBaseEventBus.instance.updateConversationIdStream,
     DataBaseEventBus.instance.insertOrReplaceMessageIdsStream,
     DataBaseEventBus.instance.updateMessageMentionStream,
-  ]).throttleTime(kDefaultThrottleDuration, trailing: true).asBroadcastStream();
+  ]).throttleTime(kDefaultThrottleDuration).asBroadcastStream();
 
   late Stream<void> circleUpdateEvent = Rx.merge([
     DataBaseEventBus.instance.updateConversationIdStream,
@@ -82,7 +82,7 @@ class ConversationListBloc extends Cubit<PagingState<ConversationItem>>
     DataBaseEventBus.instance.updateMessageMentionStream,
     DataBaseEventBus.instance.updateCircleStream,
     DataBaseEventBus.instance.updateCircleConversationStream,
-  ]).throttleTime(kDefaultThrottleDuration, trailing: true).asBroadcastStream();
+  ]).throttleTime(kDefaultThrottleDuration).asBroadcastStream();
 
   void _switchBloc(
     SlideCategoryState state,


### PR DESCRIPTION
- Fix issue with updating conversations and circles by removing trailing parameter in `throttleTime` function call in `conversation_list_bloc.dart`
- Import `bloc_concurrency.dart` and include `transformer: restartable()` for 3 events in `paging_bloc.dart`'s `on` method.