### PR TITLE
refactor: Refactor error handling for image caching.

### DIFF
--- a/lib/widgets/cache_image.dart
+++ b/lib/widgets/cache_image.dart
@@ -53,12 +53,12 @@ class CacheImage extends StatelessWidget {
       height: height,
       fit: fit,
       errorBuilder: (context, error, stackTrace) =>
-          errorWidget?.call() ?? const SizedBox.shrink(),
+          errorWidget?.call() ?? SizedBox(width: width, height: height),
       loadingBuilder: (context, child, loadingProgress) {
         if (loadingProgress == null) {
           return child;
         }
-        return placeholder?.call() ?? const SizedBox.shrink();
+        return placeholder?.call() ?? SizedBox(width: width, height: height);
       },
     );
   }

--- a/lib/widgets/message/item/sticker_message.dart
+++ b/lib/widgets/message/item/sticker_message.dart
@@ -95,7 +95,7 @@ class StickerMessageWidget extends HookWidget {
     const width = kMaxWidth;
     const height = kMaxWidth;
 
-    final placeholder = Container(
+    final errorWidget = Container(
       width: width,
       height: height,
       color: context.theme.stickerPlaceholderColor,
@@ -107,7 +107,7 @@ class StickerMessageWidget extends HookWidget {
       outerTimeAndStatusWidget: const MessageDatetimeAndStatus(),
       child: HookBuilder(
         builder: (context) {
-          if (stickerData == null) return placeholder;
+          if (stickerData == null) return errorWidget;
 
           return InteractiveDecoratedBox(
             onTap: () {
@@ -118,7 +118,7 @@ class StickerMessageWidget extends HookWidget {
             child: StickerItem(
               assetUrl: stickerData.assetUrl,
               assetType: assetType,
-              placeholder: placeholder,
+              errorWidget: errorWidget,
               width: width,
               height: height,
             ),

--- a/lib/widgets/sticker_page/sticker_item.dart
+++ b/lib/widgets/sticker_page/sticker_item.dart
@@ -13,14 +13,14 @@ class StickerItem extends HookWidget {
     super.key,
     required this.assetUrl,
     required this.assetType,
-    this.placeholder,
+    this.errorWidget,
     this.width,
     this.height,
   });
 
   final String assetUrl;
   final String? assetType;
-  final Widget? placeholder;
+  final Widget? errorWidget;
   final double? width;
   final double? height;
 
@@ -75,13 +75,17 @@ class StickerItem extends HookWidget {
               controller.duration = composition.duration;
               listener();
             },
+            errorBuilder:
+                errorWidget != null ? (_, __, ___) => errorWidget! : null,
           )
-        : CacheImage(assetUrl,
+        : CacheImage(
+            assetUrl,
             height: height,
             width: width,
             controller: playing,
             fit: BoxFit.contain,
-            placeholder: () => placeholder ?? const SizedBox());
+            errorWidget: errorWidget != null ? () => errorWidget! : null,
+          );
 
     if (width == null || height == null) {
       return AspectRatio(aspectRatio: 1, child: child);


### PR DESCRIPTION
- Improve widget clarity and replace placeholder with errorWidget
- Implement errorBuilder and use errorWidget when CacheImage fails
- Refactor error and loading builders in cache_image file to use SizedBox with specified width and height instead of using shrink() method