### PR TITLE
fix conversationProvider disposed unexpected when search conversation

### DIFF
--- a/lib/ui/provider/conversation_provider.dart
+++ b/lib/ui/provider/conversation_provider.dart
@@ -393,6 +393,7 @@ class _LastConversationNotifier extends StateNotifier<ConversationState?> {
 
 final conversationProvider = StateNotifierProvider.autoDispose<
     ConversationStateNotifier, ConversationState?>((ref) {
+  ref.keepAlive();
   final accountServerAsync = ref.watch(accountServerProvider);
 
   if (!accountServerAsync.hasValue) {


### PR DESCRIPTION
fix 
```
flutter: 2023-08-29 15:44:33.787 [E] unhandled error: Bad state: Tried to use ConversationStateNotifier after `dispose` was called.

Consider checking `mounted`.
 #0      StateNotifier._debugIsMounted.<anonymous closure> (package:state_notifier/state_notifier.dart:175:9)
#1      StateNotifier._debugIsMounted (package:state_notifier/state_notifier.dart:182:6)
#2      StateNotifier.state= (package:state_notifier/state_notifier.dart:210:12)
#3      ConversationStateNotifier.selectConversation (package:flutter_app/ui/provider/conversation_provider.dart:309:26)
<asynchronous suspension>
#4      SearchList.build.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:flutter_app/ui/home/conversation/search_list.dart:344:25)
<asynchronous suspension>
```