### PR TITLE
improve MessageLayout calculate paragraph has space

### DIFF
--- a/lib/widgets/message/message_layout.dart
+++ b/lib/widgets/message/message_layout.dart
@@ -231,10 +231,9 @@ class _RenderMessageLayout extends RenderBox
 
     final statusX = widthLimit - statusChild.size.width - spacing;
 
-    final positionForOffset = renderParagraph.getPositionForOffset(Offset(
-      statusX,
-      contentChild.size.height,
-    ));
+    // Get the last text position.
+    final positionForOffset = renderParagraph
+        .getPositionForOffset(contentChild.paintBounds.bottomRight);
 
     final boxesForSelection =
         renderParagraph.getBoxesForSelection(TextSelection(


### PR DESCRIPTION
fix TextMessage widget might be overlaped by status widget.

eg:

<img width="591" alt="image" src="https://github.com/MixinNetwork/flutter-app/assets/17426470/95056b07-db47-487c-a0cc-562b3febe642">
