### PR TITLE
fix image load failed won't reload anymore

### DIFF
--- a/lib/widgets/cache_image.dart
+++ b/lib/widgets/cache_image.dart
@@ -483,12 +483,13 @@ class MixinNetworkImageProvider
       }
     }
 
-    //Failed to load
     if (result == null) {
-      // result = await ui.instantiateImageCodec(kTransparentImage);
+      // The image failed to load, so we should evict it from the cache.
+      scheduleMicrotask(() {
+        PaintingBinding.instance.imageCache.evict(key);
+      });
       return Future<ui.Codec>.error(StateError('Failed to load $url.'));
     }
-
     return result;
   }
 


### PR DESCRIPTION
evict the image from `imageCache` when load failed.