### PR TITLE
feat: Add membership to MixinSchemeHost and update URI handling

### DIFF
--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -51,6 +51,7 @@ enum MixinSchemeHost {
   multisigs,
   swap,
   markets,
+  membership,
 }
 
 const int hour1 = 1000 * 60 * 60;

--- a/lib/utils/uri_utils.dart
+++ b/lib/utils/uri_utils.dart
@@ -119,17 +119,11 @@ Future<bool> openUri(
       );
     }
 
-    if (uri.isPay) {
-      await showUnknownMixinUrlDialog(context, uri);
-      return false;
-    }
-
-    if (uri.isMultisigs) {
-      await showUnknownMixinUrlDialog(context, uri);
-      return false;
-    }
-
-    if (uri.isSwap || uri.isMarkets) {
+    if (uri.isPay ||
+        uri.isMultisigs ||
+        uri.isSwap ||
+        uri.isMarkets ||
+        uri.isMembership) {
       await showUnknownMixinUrlDialog(context, uri);
       return false;
     }
@@ -378,6 +372,8 @@ extension _MixinUriExtension on Uri {
   bool get isMarkets =>
       _isTypeHost(MixinSchemeHost.markets) ||
       _isTypeScheme(MixinSchemeHost.markets);
+
+  bool get isMembership => _isTypeHost(MixinSchemeHost.membership);
 
   String? get startTextOfConversation {
     if (!isMixin) return null;

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -21,6 +21,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
   breakpad_client
+  jni
   mixin_logger
   ogg_opus_player
   rhttp

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -45,11 +45,11 @@ PODS:
     - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
-  - Sentry/HybridSDK (8.46.0)
-  - sentry_flutter (8.14.2):
+  - Sentry/HybridSDK (8.51.0)
+  - sentry_flutter (9.0.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.46.0)
+    - Sentry/HybridSDK (= 8.51.0)
   - sqlite3 (3.50.1):
     - sqlite3/common (= 3.50.1)
   - sqlite3/common (3.50.1)
@@ -217,8 +217,8 @@ SPEC CHECKSUMS:
   protocol_handler_macos: f9cd7b13bcaf6b0425f7410cbe52376cb843a936
   rhttp: 08d791d6373089de796318f4cfb172cbcf34e78b
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
-  Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
-  sentry_flutter: 27892878729f42701297c628eb90e7c6529f3684
+  Sentry: 861d70b4ff7c92bf6c21c70a8daab10ac7e7243c
+  sentry_flutter: ce38c4d9f9a6b9a2c23299928142b85419b3d203
   sqlite3: 1d85290c3321153511f6e900ede7a1608718bbd5
   sqlite3_flutter_libs: e7fc8c9ea2200ff3271f08f127842131746b70e2
   super_native_extensions: c2795d6d9aedf4a79fae25cb6160b71b50549189

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -25,6 +25,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
   breakpad_client
   flutter_local_notifications_windows
+  jni
   mixin_logger
   ogg_opus_player
   rhttp


### PR DESCRIPTION
- Added 'membership' to the MixinSchemeHost enum.
- Updated URI handling to include membership in the dialog for unknown mixin URLs.
- Added isMembership extension to Uri for better type checking.

This enhances the URI utility by supporting the new membership type.