### PR TITLE
fix: Update enableDelete condition in MessageItemWidget

### DIFF
--- a/lib/widgets/message/message.dart
+++ b/lib/widgets/message/message.dart
@@ -360,7 +360,7 @@ class MessageItemWidget extends HookConsumerWidget {
                             message.type.isAudio);
                     final enableRecall = !isTranscriptPage && message.canRecall;
 
-                    final enableDelete = !isTranscriptPage;
+                    final enableDelete = !isTranscriptPage && !isPinnedPage;
 
                     final addStickerMenuAction = [
                       if (message.type.isSticker)


### PR DESCRIPTION
- Modified the enableDelete variable to also consider the isPinnedPage state, ensuring that deletion is disabled when the message is pinned.