### PR TITLE
Preserve empty mention content

### DIFF
--- a/lib/ui/provider/mention_cache_provider.dart
+++ b/lib/ui/provider/mention_cache_provider.dart
@@ -101,7 +101,7 @@ class MentionCache {
   }
 
   String? replaceMention(String? s, Map<String, MentionUser> _mentionMap) {
-    if (s == null || s.isEmpty) return null;
+    if (s == null || s.isEmpty) return s;
 
     final mentionMap = _mentionMap.map(
       (key, value) => MapEntry(key.toLowerCase(), value),

--- a/test/ui/provider/mention_cache_provider_test.dart
+++ b/test/ui/provider/mention_cache_provider_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_app/ui/provider/mention_cache_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('replaceMention preserves empty content', () {
+    final mentionCache = MentionCache(null);
+
+    expect(mentionCache.replaceMention('', {}), '');
+  });
+}


### PR DESCRIPTION
## Summary
- Preserve empty strings when replacing mentions instead of converting them to null.
- Add a regression test for empty mention content.

## Why
Opening a transcript can render quoted text messages with empty quote content. Converting that empty content to null makes Flutter snapshots fail when consumers require data.

## Validation
- Ran the focused mention cache provider test.
- Ran analyzer on the changed provider and test files.