### PR TITLE
Update CI Flutter stable version

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -32,7 +32,7 @@ on:
       - 'v*'
 
 env:
-  FLUTTER_VERSION: ${{ github.event.inputs.flutter_version || '3.41.6' }}
+  FLUTTER_VERSION: ${{ github.event.inputs.flutter_version || '3.41.9' }}
   FLUTTER_CHANNEL: ${{ github.event.inputs.flutter_channel || 'stable' }}
 
 jobs:


### PR DESCRIPTION
## Summary
- Update the manual build workflow default Flutter SDK from 3.41.6 to 3.41.9.

## Why
Flutter 3.41.9 is the current stable release in the official Flutter release archive. This lets the CI/manual Windows build test whether the latest stable engine resolves the startup issue seen after the previous CI SDK bump.

## Validation
- Confirmed current stable from the official Flutter release JSON: 3.41.9 / Dart 3.11.5.
- Parsed `.github/workflows/manual-build.yml` with Ruby YAML.
- Ran `git diff --check`.
