### PR TITLE
Allow Option-click to copy profile links

### DIFF
--- a/lib/ui/home/chat_slide_page/chat_info_page.dart
+++ b/lib/ui/home/chat_slide_page/chat_info_page.dart
@@ -106,9 +106,9 @@ class ChatInfoPage extends HookConsumerWidget {
           children: [
             const SizedBox(height: 8),
             GestureDetector(
-              onLongPress: () {
-                final copy = HardwareKeyboard.instance.logicalKeysPressed
-                    .contains(LogicalKeyboardKey.altLeft);
+              onTap: () {
+                final copy =
+                    HardwareKeyboard.instance.logicalKeysPressed.hasAltKey;
                 if (copy) {
                   Clipboard.setData(
                     ClipboardData(

--- a/lib/utils/extension/src/key_event.dart
+++ b/lib/utils/extension/src/key_event.dart
@@ -84,6 +84,14 @@ final _modifierKeys = {
   LogicalKeyboardKey.fn,
 };
 
+final _altKeys = {
+  LogicalKeyboardKey.alt,
+  LogicalKeyboardKey.altLeft,
+  LogicalKeyboardKey.altRight,
+};
+
 extension SetExtension on Set<LogicalKeyboardKey> {
   bool get hasModifierKey => any(_modifierKeys.contains);
+
+  bool get hasAltKey => any(_altKeys.contains);
 }

--- a/lib/widgets/user/user_dialog.dart
+++ b/lib/widgets/user/user_dialog.dart
@@ -161,8 +161,8 @@ class _UserProfileBody extends StatelessWidget {
         children: [
           GestureDetector(
             onTap: () {
-              final copy = HardwareKeyboard.instance.logicalKeysPressed
-                  .contains(LogicalKeyboardKey.altLeft);
+              final copy =
+                  HardwareKeyboard.instance.logicalKeysPressed.hasAltKey;
               if (copy) {
                 Clipboard.setData(
                   ClipboardData(text: 'mixin://users/${user.userId}'),

--- a/test/utils/key_event_extension_test.dart
+++ b/test/utils/key_event_extension_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_app/utils/extension/extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SetExtension.hasAltKey', () {
+    test('returns true for either Alt key', () {
+      expect({LogicalKeyboardKey.altLeft}.hasAltKey, isTrue);
+      expect({LogicalKeyboardKey.altRight}.hasAltKey, isTrue);
+      expect({LogicalKeyboardKey.alt}.hasAltKey, isTrue);
+    });
+
+    test('returns false when no Alt key is pressed', () {
+      expect({LogicalKeyboardKey.metaLeft}.hasAltKey, isFalse);
+      expect(<LogicalKeyboardKey>{}.hasAltKey, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Allow Option-click/tap on the chat info avatar to copy the conversation deeplink immediately.
- Reuse shared Alt-key detection for the conversation and user profile hidden copy affordances.
- Support either Option key instead of only the left Option key.

## Validation
- Ran the targeted key-event unit test.
- Ran focused Flutter analysis on the touched files.
- Checked the staged diff for whitespace errors.