### PR TITLE
Fix chat bubble blink and tail-follow scroll

### DIFF
--- a/lib/ui/home/chat/chat_jump_trace.dart
+++ b/lib/ui/home/chat/chat_jump_trace.dart
@@ -3,10 +3,17 @@ import 'package:flutter/widgets.dart';
 import '../../../utils/logger.dart';
 
 const chatJumpTraceEnabled = bool.fromEnvironment('MIXIN_CHAT_JUMP_TRACE');
+const chatScrollTraceEnabled =
+    bool.fromEnvironment('MIXIN_CHAT_SCROLL_TRACE') || chatJumpTraceEnabled;
 
 void traceChatJump(String message) {
   if (!chatJumpTraceEnabled) return;
   i('[chat-jump] $message');
+}
+
+void traceChatScroll(String message) {
+  if (!chatScrollTraceEnabled) return;
+  i('[chat-scroll] $message');
 }
 
 String shortMessageId(String? messageId) {

--- a/lib/ui/home/chat/chat_scroll_coordinator.dart
+++ b/lib/ui/home/chat/chat_scroll_coordinator.dart
@@ -102,6 +102,9 @@ class ChatScrollCoordinator {
   int _programmaticBottomScrollDepth = 0;
   int _jumpButtonFrozenUpdates = 0;
   bool _followTailAfterProgrammaticScroll = false;
+  double _lastTracedScrollPixels = double.nan;
+  double _lastTracedScrollMax = double.nan;
+  double _lastTracedScrollDistanceToBottom = double.nan;
 
   void captureViewportState(
     List<MessageItem> messages,
@@ -113,6 +116,12 @@ class ChatScrollCoordinator {
     _tailFollowAnchorSnapshot = _tailFollowEligible
         ? _tailFollowAnchorSnapshotFromViewport()
         : null;
+    traceChatScroll(
+      'capture tailEligible=$_tailFollowEligible '
+      'anchor=${shortMessageId(_tailFollowAnchorSnapshot?.messageId)} '
+      'anchorBottom=${formatDouble(_tailFollowAnchorSnapshot?.bottom)} '
+      '${_formatScrollState()}',
+    );
   }
 
   void updateMessages(
@@ -237,6 +246,16 @@ class ChatScrollCoordinator {
     _scheduleViewportStateUpdate(
       updateVisibleDate: notification is ScrollEndNotification,
     );
+    if (notification is ScrollStartNotification ||
+        notification is ScrollEndNotification ||
+        notification is UserScrollNotification) {
+      traceChatScroll(
+        'notification ${notification.runtimeType} '
+        'direction=${notification is UserScrollNotification ? notification.direction : '-'} '
+        'drag=${notification is ScrollStartNotification ? notification.dragDetails != null : '-'} '
+        '${formatScrollMetrics(notification.metrics)}',
+      );
+    }
     _unlockPreloadOnUserScrollIntent(notification);
     if (notification is! ScrollUpdateNotification) return false;
     if (_programmaticScrollDepth > 0) {
@@ -505,6 +524,10 @@ class ChatScrollCoordinator {
   }) async {
     _clearJumpButtonFreeze();
     _programmaticBottomScrollDepth++;
+    traceChatScroll(
+      'bottom-jump start animated=$animated '
+      'direction=$animationDirection ${_formatScrollState()}',
+    );
     try {
       await _jumpToClamped(
         scrollController.position.maxScrollExtent,
@@ -514,6 +537,7 @@ class ChatScrollCoordinator {
       );
     } finally {
       _programmaticBottomScrollDepth--;
+      traceChatScroll('bottom-jump done ${_formatScrollState()}');
     }
   }
 
@@ -744,10 +768,16 @@ class ChatScrollCoordinator {
       'delta=${formatDouble(delta)} start=${formatDouble(start)} '
       '${formatScrollMetrics(position)}',
     );
-    scrollController.jumpTo(start);
+    traceChatScroll(
+      'tail-follow start anchor=${shortMessageId(snapshot.messageId)} '
+      'delta=${formatDouble(delta)} start=${formatDouble(start)} '
+      '${_formatScrollState()}',
+    );
+    scrollController.position.correctPixels(start);
   }
 
   void _scheduleScrollPositionUpdate() {
+    _traceScrollPosition();
     _scheduleViewportStateUpdate(updateVisibleDate: false);
   }
 
@@ -791,6 +821,13 @@ class ChatScrollCoordinator {
     List<MessageItem> messages,
     Map<String, GlobalKey> keysByMessageId,
   ) {
+    final previousCount = _messages.length;
+    final previousBottomMessageId = _messages.isEmpty
+        ? null
+        : _messages.last.messageId;
+    final nextBottomMessageId = messages.isEmpty
+        ? null
+        : messages.last.messageId;
     final messageWindowChanged = !_hasSameMessageIds(messages);
     if (!identical(_messages, messages)) {
       _messages = messages;
@@ -801,6 +838,12 @@ class ChatScrollCoordinator {
     }
     if (messageWindowChanged) {
       _freezeJumpButton();
+      traceChatScroll(
+        'messages changed count=$previousCount->${messages.length} '
+        'bottom=${shortMessageId(previousBottomMessageId)}'
+        '->${shortMessageId(nextBottomMessageId)} '
+        '${_formatScrollState()}',
+      );
     }
     _keysByMessageId = keysByMessageId;
   }
@@ -843,6 +886,40 @@ class ChatScrollCoordinator {
   RenderBox? get _viewportRender {
     final object = _viewportKey?.currentContext?.findRenderObject();
     return object is RenderBox ? object : null;
+  }
+
+  void _traceScrollPosition() {
+    if (!chatScrollTraceEnabled || !scrollController.hasClients) return;
+    final position = scrollController.position;
+    if (!position.hasContentDimensions) return;
+    final distanceToBottom = _distanceToBottom();
+    final pixels = position.pixels;
+    final max = position.maxScrollExtent;
+    final shouldTrace =
+        _lastTracedScrollPixels.isNaN ||
+        (pixels - _lastTracedScrollPixels).abs() >= 1 ||
+        (max - _lastTracedScrollMax).abs() >= 1 ||
+        (distanceToBottom - _lastTracedScrollDistanceToBottom).abs() >= 1;
+    if (!shouldTrace) return;
+    _lastTracedScrollPixels = pixels;
+    _lastTracedScrollMax = max;
+    _lastTracedScrollDistanceToBottom = distanceToBottom;
+    traceChatScroll(
+      'position distanceBottom=${formatDouble(distanceToBottom)} '
+      'programmatic=$_programmaticScrollDepth '
+      'bottomProgrammatic=$_programmaticBottomScrollDepth '
+      'followPending=$_followTailAfterProgrammaticScroll '
+      '${formatScrollMetrics(position)}',
+    );
+  }
+
+  String _formatScrollState() {
+    if (!scrollController.hasClients) return 'no-scroll-client';
+    return 'distanceBottom=${formatDouble(_distanceToBottom())} '
+        'programmatic=$_programmaticScrollDepth '
+        'bottomProgrammatic=$_programmaticBottomScrollDepth '
+        'messages=${_messages.length} '
+        '${formatScrollMetrics(scrollController.position)}';
   }
 
   void _traceTargetAfterLayout(

--- a/lib/ui/home/notifier/message_controller.dart
+++ b/lib/ui/home/notifier/message_controller.dart
@@ -615,9 +615,19 @@ class MessageController extends ValueNotifier<MessageState> {
       return;
     }
 
+    traceChatScroll(
+      'insert current conv=${shortMessageId(conversationId)} '
+      'incoming=${list.length} '
+      'ids=${list.map((e) => shortMessageId(e.messageId)).join(',')} '
+      'stateLatest=${state.isLatest} '
+      'stateBottom=${shortMessageId(state.bottomMessage?.messageId)}',
+    );
     final result = _insertOrReplace(conversationId, list);
     if (result != null) {
+      traceChatScroll('insert emit ${_formatWindow(result)}');
       _emit(_pretreatment(result));
+    } else {
+      traceChatScroll('insert reload-latest requested');
     }
   }
 

--- a/lib/widgets/message/item/action/action_message.dart
+++ b/lib/widgets/message/item/action/action_message.dart
@@ -55,7 +55,7 @@ class ActionMessage extends HookConsumerWidget {
   }
 }
 
-class ActionMessageButton extends ConsumerWidget {
+class ActionMessageButton extends HookConsumerWidget {
   const ActionMessageButton({required this.action, super.key});
 
   final ActionData action;
@@ -67,6 +67,68 @@ class ActionMessageButton extends ConsumerWidget {
       showNip: false,
       nipPadding: false,
     );
+    final highlightEnabled = useMessageHighlightEnabled();
+    final menuHighlighted = useMessageMenuHighlighted();
+    Widget button = CustomPaint(
+      painter: BubblePainter(
+        color: context.theme.primary,
+        clipper: bubbleClipper,
+      ),
+      child: IntrinsicWidth(
+        child: Stack(
+          fit: StackFit.passthrough,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+              child: Text(
+                action.label,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: context.messageStyle.secondaryFontSize,
+                  color: colorHex(action.color) ?? Colors.black,
+                  height: 1,
+                ),
+              ),
+            ),
+            if (action.isSendUserLink)
+              Align(
+                alignment: Alignment.topRight,
+                child: Padding(
+                  padding: const EdgeInsets.all(6),
+                  child: SvgPicture.asset(
+                    Resources.assetsImagesLinkSendSvg,
+                    width: 8,
+                    height: 8,
+                  ),
+                ),
+              )
+            else if (action.isExternalLink)
+              Align(
+                alignment: Alignment.topRight,
+                child: Padding(
+                  padding: const EdgeInsets.all(6),
+                  child: SvgPicture.asset(
+                    Resources.assetsImagesExternalLinkSvg,
+                    width: 6,
+                    height: 6,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (highlightEnabled || menuHighlighted) {
+      button = MessageBubbleHighlight(
+        messageId: context.message.messageId,
+        enabled: highlightEnabled,
+        clipper: bubbleClipper,
+        currentUser: false,
+        media: true,
+        menuHighlighted: menuHighlighted,
+        child: button,
+      );
+    }
     return InteractiveDecoratedBox.color(
       cursor: SystemMouseCursors.click,
       onTap: () {
@@ -78,58 +140,7 @@ class ActionMessageButton extends ConsumerWidget {
           conversationId: ref.read(currentConversationIdProvider),
         );
       },
-      child: CustomPaint(
-        painter: BubblePainter(
-          color: context.theme.primary,
-          clipper: bubbleClipper,
-        ),
-        child: IntrinsicWidth(
-          child: Stack(
-            fit: StackFit.passthrough,
-            children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 14,
-                  vertical: 8,
-                ),
-                child: Text(
-                  action.label,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: context.messageStyle.secondaryFontSize,
-                    color: colorHex(action.color) ?? Colors.black,
-                    height: 1,
-                  ),
-                ),
-              ),
-              if (action.isSendUserLink)
-                Align(
-                  alignment: Alignment.topRight,
-                  child: Padding(
-                    padding: const EdgeInsets.all(6),
-                    child: SvgPicture.asset(
-                      Resources.assetsImagesLinkSendSvg,
-                      width: 8,
-                      height: 8,
-                    ),
-                  ),
-                )
-              else if (action.isExternalLink)
-                Align(
-                  alignment: Alignment.topRight,
-                  child: Padding(
-                    padding: const EdgeInsets.all(6),
-                    child: SvgPicture.asset(
-                      Resources.assetsImagesExternalLinkSvg,
-                      width: 6,
-                      height: 6,
-                    ),
-                  ),
-                ),
-            ],
-          ),
-        ),
-      ),
+      child: button,
     );
   }
 }

--- a/lib/widgets/message/item/action_card/actions_card.dart
+++ b/lib/widgets/message/item/action_card/actions_card.dart
@@ -74,9 +74,11 @@ class _Bubble extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final isCurrentUser = useIsCurrentUser();
+    final highlightEnabled = useMessageHighlightEnabled();
+    final menuHighlighted = useMessageMenuHighlighted();
     final clipper = BubbleClipper(currentUser: isCurrentUser, showNip: true);
     final bubbleColor = context.messageBubbleColor(isCurrentUser);
-    return CustomPaint(
+    Widget bubble = CustomPaint(
       painter: BubblePainter(color: bubbleColor, clipper: clipper),
       child: ClipPath(
         clipper: clipper,
@@ -86,6 +88,18 @@ class _Bubble extends HookWidget {
         ),
       ),
     );
+    if (highlightEnabled || menuHighlighted) {
+      bubble = MessageBubbleHighlight(
+        messageId: context.message.messageId,
+        enabled: highlightEnabled,
+        clipper: clipper,
+        currentUser: isCurrentUser,
+        media: false,
+        menuHighlighted: menuHighlighted,
+        child: bubble,
+      );
+    }
+    return bubble;
   }
 }
 

--- a/lib/widgets/message/message_bubble.dart
+++ b/lib/widgets/message/message_bubble.dart
@@ -142,8 +142,9 @@ class MessageBubble extends HookConsumerWidget {
       );
     }
 
-    if (highlightEnabled || menuHighlighted) {
-      _child = _MessageBubbleHighlight(
+    final hasHighlightSurface = hasQuoteMessage || showBubble || highlightMedia;
+    if (hasHighlightSurface && (highlightEnabled || menuHighlighted)) {
+      _child = MessageBubbleHighlight(
         messageId: context.message.messageId,
         enabled: highlightEnabled,
         clipper: clipper,
@@ -240,8 +241,8 @@ class MessageBubble extends HookConsumerWidget {
   }
 }
 
-class _MessageBubbleHighlight extends StatefulWidget {
-  const _MessageBubbleHighlight({
+class MessageBubbleHighlight extends StatefulWidget {
+  const MessageBubbleHighlight({
     required this.messageId,
     required this.enabled,
     required this.clipper,
@@ -249,6 +250,7 @@ class _MessageBubbleHighlight extends StatefulWidget {
     required this.media,
     required this.menuHighlighted,
     required this.child,
+    super.key,
   });
 
   final String messageId;
@@ -260,11 +262,10 @@ class _MessageBubbleHighlight extends StatefulWidget {
   final Widget child;
 
   @override
-  State<_MessageBubbleHighlight> createState() =>
-      _MessageBubbleHighlightState();
+  State<MessageBubbleHighlight> createState() => _MessageBubbleHighlightState();
 }
 
-class _MessageBubbleHighlightState extends State<_MessageBubbleHighlight> {
+class _MessageBubbleHighlightState extends State<MessageBubbleHighlight> {
   BlinkNotifier? _notifier;
   BlinkState _blinkState = const BlinkState();
 

--- a/test/ui/home/chat/chat_scroll_coordinator_test.dart
+++ b/test/ui/home/chat/chat_scroll_coordinator_test.dart
@@ -603,7 +603,7 @@ void main() {
   });
 
   testWidgets(
-    'scheduleRestore restores tail-follow start in centered viewports',
+    'scheduleRestore animates tail-follow without jump notifications',
     (tester) async {
       final coordinator = TrackingChatScrollCoordinator();
       final centerKey = GlobalKey();
@@ -647,7 +647,8 @@ void main() {
         ..animateCount = 0
         ..jumpCount = 0
         ..jumpOffsets.clear()
-        ..animateOffsets.clear();
+        ..animateOffsets.clear()
+        ..animationCompleter = Completer<void>();
       coordinator.scheduleRestore(
         messages: nextMessages,
         keysByMessageId: keysByMessageId,
@@ -657,9 +658,9 @@ void main() {
       await tester.pump();
 
       expect(coordinator.trackingScrollController.animateCount, 1);
-      expect(coordinator.trackingScrollController.jumpCount, 1);
+      expect(coordinator.trackingScrollController.jumpCount, 0);
       expect(
-        coordinator.trackingScrollController.jumpOffsets.single,
+        coordinator.scrollController.offset,
         lessThan(coordinator.trackingScrollController.animateOffsets.single),
       );
     },

--- a/test/widgets/message/message_context_test.dart
+++ b/test/widgets/message/message_context_test.dart
@@ -10,6 +10,8 @@ import 'package:flutter_app/ui/provider/setting_provider.dart';
 import 'package:flutter_app/utils/hook.dart';
 import 'package:flutter_app/widgets/brightness_observer.dart';
 import 'package:flutter_app/widgets/high_light_text.dart';
+import 'package:flutter_app/widgets/message/item/action/action_data.dart';
+import 'package:flutter_app/widgets/message/item/action/action_message.dart';
 import 'package:flutter_app/widgets/message/item/quote_message.dart';
 import 'package:flutter_app/widgets/message/item/text/selectable.dart'
     as message_selectable;
@@ -154,14 +156,7 @@ void main() {
     );
     await tester.pump();
 
-    final highlightPainters = tester
-        .widgetList<CustomPaint>(find.byType(CustomPaint))
-        .where(
-          (paint) =>
-              paint.foregroundPainter.runtimeType.toString() ==
-              '_MessageBubbleHighlightPainter',
-        )
-        .toList();
+    final highlightPainters = _highlightPainters(tester);
     final opacity = messageHighlightOpacityForTesting(
       tester.element(find.byType(MessageBubble)),
       currentUser: true,
@@ -173,6 +168,63 @@ void main() {
 
     await tester.pumpWidget(const SizedBox.shrink());
     notifier.dispose();
+  });
+
+  testWidgets(
+    'showBubble false wrapper does not blink without a bubble surface',
+    (
+      tester,
+    ) async {
+      final notifier = BlinkNotifier(tester)..blinkByMessageId('1');
+
+      await tester.pumpWidget(
+        _MessageTestScope(
+          blinkNotifier: notifier,
+          child: MessageContext.fromMessageItem(
+            message: testMessage('1'),
+            child: const MessageBubble(
+              showBubble: false,
+              padding: EdgeInsets.zero,
+              child: SizedBox(width: 80, height: 20),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final highlightPainters = _highlightPainters(tester);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      notifier.dispose();
+
+      expect(highlightPainters, isEmpty);
+    },
+  );
+
+  testWidgets('action buttons blink their bubble surface', (tester) async {
+    final notifier = BlinkNotifier(tester)..blinkByMessageId('1');
+
+    await tester.pumpWidget(
+      _MessageTestScope(
+        blinkNotifier: notifier,
+        child: MessageContext.fromMessageItem(
+          message: testMessage('1'),
+          child: Center(
+            child: ActionMessageButton(
+              action: ActionData('Open', '#000000', 'https://example.com'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final highlightPainters = _highlightPainters(tester);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    notifier.dispose();
+
+    expect(highlightPainters, hasLength(1));
   });
 
   testWidgets('double tapping a message starts a quote reply', (tester) async {
@@ -542,6 +594,15 @@ String _richTextPlainText(WidgetTester tester) => tester
     )
     .map((widget) => widget.text.toPlainText())
     .join('\n');
+
+List<CustomPaint> _highlightPainters(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.byType(CustomPaint))
+    .where(
+      (paint) =>
+          paint.foregroundPainter.runtimeType.toString() ==
+          '_MessageBubbleHighlightPainter',
+    )
+    .toList();
 
 MessageItem testMessage(
   String id, {


### PR DESCRIPTION
## Summary
- Keep message blink painting on actual bubble, media, quote, action card, and action button surfaces.
- Preserve bottom tail-follow animation for newly appended messages without emitting a visible jump first.
- Add focused widget coverage for bubble blink surfaces and tail-follow scroll animation.
- Add opt-in chat scroll trace logging behind MIXIN_CHAT_SCROLL_TRACE for future scroll diagnosis.

## Tests
- flutter test test/widgets/message/message_context_test.dart
- flutter test test/ui/home/chat/chat_scroll_coordinator_test.dart
- flutter analyze affected chat bubble and scroll files