### PR TITLE
Fix voice recorder overlay cleanup

### DIFF
--- a/lib/ui/home/chat/voice_recorder_bottom_bar.dart
+++ b/lib/ui/home/chat/voice_recorder_bottom_bar.dart
@@ -46,14 +46,7 @@ class VoiceRecorderBarOverlayComposition extends HookConsumerWidget {
 
     final overlay = Navigator.of(context).overlay ?? Overlay.of(context);
 
-    final recorderBottomBarEntry = useRef<OverlayEntry?>(null);
-
     useEffect(() {
-      final previousEntry = recorderBottomBarEntry.value;
-      if (previousEntry?.mounted ?? false) {
-        previousEntry?.remove();
-      }
-      recorderBottomBarEntry.value = null;
       if (!isRecorderMode) {
         return null;
       }
@@ -77,19 +70,17 @@ class VoiceRecorderBarOverlayComposition extends HookConsumerWidget {
               ),
             ),
       );
-      recorderBottomBarEntry.value = entry;
       var disposed = false;
+      var inserted = false;
       WidgetsBinding.instance.scheduleFrameCallback((timeStamp) {
         if (disposed) return;
         overlay.insert(entry);
+        inserted = true;
       });
       return () {
         disposed = true;
-        if (entry.mounted) {
+        if (inserted) {
           entry.remove();
-        }
-        if (recorderBottomBarEntry.value == entry) {
-          recorderBottomBarEntry.value = null;
         }
       };
     }, [isRecorderMode, layoutWidth]);

--- a/test/ui/home/chat/voice_recorder_overlay_test.dart
+++ b/test/ui/home/chat/voice_recorder_overlay_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/constants/brightness_theme_data.dart';
+import 'package:flutter_app/ui/home/chat/voice_recorder_bottom_bar.dart';
+import 'package:flutter_app/utils/audio_message_player/audio_message_service.dart';
+import 'package:flutter_app/widgets/brightness_observer.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart' hide ChangeNotifierProvider;
+import 'package:provider/provider.dart';
+
+void main() {
+  testWidgets('exiting record mode removes the overlay once', (tester) async {
+    final notifier = VoiceRecorderNotifier(_FakeAudioMessagePlayService())
+      ..value = const VoiceRecorderState(status: VoiceRecorderStatus.recording);
+    addTearDown(() {
+      notifier
+        ..value = const VoiceRecorderState(status: VoiceRecorderStatus.idle)
+        ..dispose();
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: BrightnessData(
+          value: 0,
+          brightnessThemeData: lightBrightnessThemeData,
+          child: MaterialApp(
+            home: Scaffold(
+              body: Align(
+                alignment: Alignment.bottomCenter,
+                child: SizedBox(
+                  height: 56,
+                  width: 600,
+                  child: ChangeNotifierProvider<VoiceRecorderNotifier>.value(
+                    value: notifier,
+                    child: const VoiceRecorderBarOverlayComposition(
+                      layoutWidth: 600,
+                      child: SizedBox.expand(),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(VoiceRecorderBottomBar), findsOneWidget);
+
+    notifier.value = const VoiceRecorderState(status: VoiceRecorderStatus.idle);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(VoiceRecorderBottomBar), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+class _FakeAudioMessagePlayService implements AudioMessagePlayService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
## Summary
- Give each recording overlay entry one cleanup owner.
- Avoid removing an entry before its scheduled insertion.
- Cover the recording-to-idle transition with a widget test.

## Validation
- flutter test --no-pub --reporter expanded test/ui/home/chat/voice_recorder_overlay_test.dart
- flutter analyze --no-pub lib/ui/home/chat/voice_recorder_bottom_bar.dart test/ui/home/chat/voice_recorder_overlay_test.dart