### PR TITLE
Fix exited groups appearing in conversation search

### DIFF
--- a/lib/db/dao/conversation_dao.dart
+++ b/lib/db/dao/conversation_dao.dart
@@ -113,6 +113,10 @@ class ConversationDao extends DatabaseAccessor<MixinDatabase>
     return predicate;
   }
 
+  Expression<bool> _sendableConversationPredicate(Conversations conversation) =>
+      conversation.category.equalsValue(ConversationCategory.group).not() |
+      conversation.status.equalsValue(ConversationStatus.quit).not();
+
   Future<int> conversationCountByCategory(SlideCategoryType category) =>
       _baseConversationItemCount(
         (conversation, owner, circle) =>
@@ -501,22 +505,24 @@ class ConversationDao extends DatabaseAccessor<MixinDatabase>
       return _fuzzySearchConversationInCircle(
         query.trim().escapeSql(),
         category!.id,
-        (conversation, owner, message, _, cc, _) => filterUnseen
-            ? conversation.unseenMessageCount.isBiggerThanValue(0)
-            : ignoreWhere,
+        (conversation, owner, message, _, cc, _) =>
+            _sendableConversationPredicate(conversation) &
+            (filterUnseen
+                ? conversation.unseenMessageCount.isBiggerThanValue(0)
+                : ignoreWhere),
         (conversation, owner, message, _, cc, _) => Limit(limit, null),
       );
     }
     return _fuzzySearchConversation(
       query.trim().escapeSql(),
       (conversation, owner, message, _, _) {
-        Expression<bool> predicate = ignoreWhere;
+        var predicate = _sendableConversationPredicate(conversation);
         switch (category?.type) {
           case SlideCategoryType.contacts:
           case SlideCategoryType.groups:
           case SlideCategoryType.bots:
           case SlideCategoryType.strangers:
-            predicate = _conversationPredicateByCategory(
+            predicate &= _conversationPredicateByCategory(
               category!.type,
               conversation,
               owner,
@@ -559,19 +565,24 @@ class ConversationDao extends DatabaseAccessor<MixinDatabase>
       db.fuzzySearchConversationItem(
         keyword.trim(),
         (conversation, user) =>
-            (conversation.category.equalsValue(ConversationCategory.group))
-            //
-            |
-            //
-            (conversation.category.equalsValue(ConversationCategory.contact) &
-                user.relationship.equalsValue(UserRelationship.stranger)),
+            _sendableConversationPredicate(conversation) &
+            ((conversation.category.equalsValue(ConversationCategory.group))
+                //
+                |
+                //
+                (conversation.category.equalsValue(
+                      ConversationCategory.contact,
+                    ) &
+                    user.relationship.equalsValue(UserRelationship.stranger))),
         (conversation, user) => maxLimit,
       );
 
   Selectable<SearchItem> fuzzySearchConversationItemByIds(List<String> ids) =>
       db.fuzzySearchConversationItem(
         '',
-        (conversation, user) => conversation.conversationId.isIn(ids),
+        (conversation, user) =>
+            _sendableConversationPredicate(conversation) &
+            conversation.conversationId.isIn(ids),
         (conversation, user) => maxLimit,
       );
 

--- a/test/db/conversation_dao_test.dart
+++ b/test/db/conversation_dao_test.dart
@@ -1,0 +1,109 @@
+@TestOn('linux || mac-os')
+library;
+
+import 'package:drift/native.dart';
+import 'package:flutter_app/db/mixin_database.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart'
+    show ConversationCategory, ConversationStatus, UserRelationship;
+
+void main() {
+  test('conversation searches exclude quit groups but keep contacts', () async {
+    final database = MixinDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+
+    final now = DateTime(2026);
+    await database.batch((batch) {
+      batch
+        ..insertAll(database.users, [
+          const User(
+            userId: 'active-owner',
+            identityNumber: '7001',
+            fullName: 'Active Group Owner',
+            relationship: UserRelationship.friend,
+          ),
+          const User(
+            userId: 'quit-owner',
+            identityNumber: '7002',
+            fullName: 'Quit Group Owner',
+            relationship: UserRelationship.friend,
+          ),
+          const User(
+            userId: 'quit-contact-owner',
+            identityNumber: '7003',
+            fullName: 'Quit Contact Owner',
+            relationship: UserRelationship.stranger,
+          ),
+        ])
+        ..insertAll(database.conversations, [
+          Conversation(
+            conversationId: 'active-group',
+            ownerId: 'active-owner',
+            category: ConversationCategory.group,
+            name: 'Active Group',
+            createdAt: now,
+            status: ConversationStatus.success,
+          ),
+          Conversation(
+            conversationId: 'quit-group',
+            ownerId: 'quit-owner',
+            category: ConversationCategory.group,
+            name: 'Quit Group',
+            createdAt: now,
+            status: ConversationStatus.quit,
+          ),
+          Conversation(
+            conversationId: 'quit-contact',
+            ownerId: 'quit-contact-owner',
+            category: ConversationCategory.contact,
+            createdAt: now,
+            status: ConversationStatus.quit,
+          ),
+        ]);
+    });
+
+    final typedPaletteResults = await database.conversationDao
+        .fuzzySearchConversationItem('Group')
+        .get();
+    expect(
+      typedPaletteResults.map((item) => item.id).toSet(),
+      {'active-group', 'quit-contact'},
+    );
+
+    final recentPaletteResults = await database.conversationDao
+        .fuzzySearchConversationItemByIds([
+          'quit-group',
+          'active-group',
+          'quit-contact',
+        ])
+        .get();
+    expect(
+      recentPaletteResults.map((item) => item.id).toSet(),
+      {'active-group', 'quit-contact'},
+    );
+
+    final quitContactResults = await database.conversationDao
+        .fuzzySearchConversationItem('Quit Contact')
+        .get();
+    expect(
+      quitContactResults.map((item) => item.id).toSet(),
+      {'active-group', 'quit-contact'},
+    );
+
+    final regularSearchResults = await database.conversationDao
+        .fuzzySearchConversation('Group', 32)
+        .get();
+    expect(
+      regularSearchResults.map((item) => item.conversationId),
+      ['active-group'],
+    );
+
+    final regularQuitContactResults = await database.conversationDao
+        .fuzzySearchConversation('Quit Contact', 32)
+        .get();
+    expect(
+      regularQuitContactResults.map((item) => item.conversationId).toSet(),
+      {'active-group', 'quit-contact'},
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- exclude exited group conversations from Cmd+K keyword and recent suggestions
- apply the same sendability predicate to regular conversation search
- keep sendable contacts searchable and add DAO regression coverage

## Validation
- `flutter test --no-pub test/db/conversation_dao_test.dart`
- Dart analysis for the affected DAO and test