### PR TITLE
Stop API retries when app upgrade is required

### DIFF
--- a/lib/account/account_server.dart
+++ b/lib/account/account_server.dart
@@ -60,6 +60,7 @@ class AccountServer {
   });
 
   static String? sid;
+  static final _upgradeGate = ApiUpgradeGate();
 
   set language(String language) =>
       client.dio.options.headers['Accept-Language'] = language;
@@ -111,7 +112,9 @@ class AccountServer {
     } on MixinApiError catch (e) {
       final err = e.error;
       if (err is MixinError && err.code == oldVersion) {
-        _isUpdateRequired.value = true;
+        checkSignalKeyTimer?.cancel();
+        checkSignalKeyTimer = null;
+        _requireUpgrade();
       }
       return;
     } catch (e, s) {
@@ -133,6 +136,14 @@ class AccountServer {
   final BehaviorSubject<bool> _isUpdateRequired = BehaviorSubject<bool>();
 
   ValueStream<bool> get isUpdateRequired => _isUpdateRequired;
+
+  void _requireUpgrade() {
+    if (!_upgradeGate.require()) return;
+    _isUpdateRequired.value = true;
+    if (_isolateChannel != null) {
+      _sendEventToWorkerIsolate(MainIsolateEventType.requireUpgrade);
+    }
+  }
 
   Future<void> _onClientRequestError(DioException e) async {
     if (e is MixinApiError) {
@@ -165,7 +176,7 @@ class AccountServer {
         await signOutAndClear();
         multiAuthNotifier.signOut();
       } else if (mixinError.code == oldVersion) {
-        _isUpdateRequired.value = true;
+        _requireUpgrade();
       }
     }
   }
@@ -190,6 +201,8 @@ class AccountServer {
           },
         ),
       ],
+      upgradeGate: _upgradeGate,
+      onUpgradeRequired: _requireUpgrade,
     )..configProxySetting(database.settingProperties);
 
     attachmentUtil = AttachmentUtil.init(client, database, identityNumber);
@@ -287,6 +300,8 @@ class AccountServer {
         _connectedStateBehaviorSubject.add(event.argument as ConnectedState);
       case WorkerIsolateEventType.onApiRequestedError:
         _onClientRequestError(event.argument as DioException);
+      case WorkerIsolateEventType.onUpgradeRequired:
+        _requireUpgrade();
       case WorkerIsolateEventType.requestDownloadAttachment:
         final request = event.argument as AttachmentRequest;
         _onAttachmentDownloadRequest(request);

--- a/lib/blaze/blaze.dart
+++ b/lib/blaze/blaze.dart
@@ -14,6 +14,7 @@ import '../db/extension/job.dart';
 import '../db/mixin_database.dart';
 import '../utils/extension/extension.dart';
 import '../utils/logger.dart';
+import '../utils/mixin_api_client.dart';
 import '../utils/proxy.dart';
 import '../workers/job/ack_job.dart';
 import '../workers/job/flood_job.dart';
@@ -51,8 +52,10 @@ class Blaze {
     this.client,
     this.userAgent,
     this.ackJob,
-    this.floodJob,
-  ) {
+    this.floodJob, {
+    required this.upgradeGate,
+    this.onUpgradeRequired,
+  }) {
     database.settingProperties.addListener(_onProxySettingChanged);
     proxyConfig = database.settingProperties.activatedProxy;
 
@@ -69,6 +72,8 @@ class Blaze {
   final Client client;
   final AckJob ackJob;
   final FloodJob floodJob;
+  final ApiUpgradeGate upgradeGate;
+  final void Function()? onUpgradeRequired;
 
   final String? userAgent;
 
@@ -113,6 +118,7 @@ class Blaze {
 
   Timer? _checkTimeoutTimer;
   Timer? _reconnectTimer;
+  bool _stoppedForUpgrade = false;
 
   // --- Event Stream ---
   final StreamController<_ConnectionEvent> _eventController =
@@ -124,6 +130,10 @@ class Blaze {
   // ==========================================================================
 
   void _handleConnectionEvent(_ConnectionEvent event) {
+    if (_stoppedForUpgrade) {
+      i('Ignoring connection event after upgrade requirement: $event');
+      return;
+    }
     i(
       '[_handleConnectionEvent] Received event: $event, Current state: $_connectedState',
     );
@@ -180,7 +190,9 @@ class Blaze {
   void _scheduleRetry() {
     _reconnectTimer?.cancel(); // Cancel previous timer
     // Ensure we're in a state that should retry
-    if (_connectedState != ConnectedState.reconnecting) {
+    if (_stoppedForUpgrade ||
+        upgradeGate.isRequired ||
+        _connectedState != ConnectedState.reconnecting) {
       i('Not scheduling retry, state is $_connectedState');
       return;
     }
@@ -196,6 +208,7 @@ class Blaze {
   }
 
   void _connect() {
+    if (_stoppedForUpgrade || upgradeGate.isRequired) return;
     i('reconnecting set false, ${StackTrace.current}');
     _connectedState = ConnectedState.connecting;
 
@@ -229,6 +242,15 @@ class Blaze {
           .asyncMap(parseBlazeMessage)
           .listen(
             (blazeMessage) async {
+              if (blazeMessage.action == kErrorAction &&
+                  blazeMessage.error?.code == oldVersion) {
+                final transaction = transactions.remove(blazeMessage.id);
+                transaction?.error(blazeMessage);
+                if (upgradeGate.require()) onUpgradeRequired?.call();
+                stopForUpgrade();
+                return;
+              }
+
               _connectedState = ConnectedState.connected;
               d('blazeMessage receive: ${blazeMessage.toJson()}');
 
@@ -412,6 +434,7 @@ class Blaze {
         .getSingleOrNull();
     var status = offset != null ? offset.epochNano : DateTime.now().epochNano;
     for (;;) {
+      if (_stoppedForUpgrade || upgradeGate.isRequired) return;
       final response = await client.messageApi.messageStatusOffset(status);
       final blazeMessages = response.data;
       if (blazeMessages.isEmpty) {
@@ -461,6 +484,9 @@ class Blaze {
   }
 
   Future<BlazeMessage?> sendMessage(BlazeMessage blazeMessage) async {
+    if (_stoppedForUpgrade || upgradeGate.isRequired) {
+      throw const ApiUpgradeRequiredException();
+    }
     if (_connectedState != ConnectedState.connected) {
       w('Cannot send message, not connected. State: $_connectedState');
       return null;
@@ -488,6 +514,7 @@ class Blaze {
 
   Future<void> connect() async {
     i('Public connect called. Current state: $_connectedState');
+    if (_stoppedForUpgrade || upgradeGate.isRequired) return;
     if (_connectedState == ConnectedState.connecting ||
         _connectedState == ConnectedState.reconnecting) {
       return;
@@ -498,6 +525,7 @@ class Blaze {
 
   Future<void> reconnect() async {
     i('Public reconnect called. Current state: $_connectedState');
+    if (_stoppedForUpgrade || upgradeGate.isRequired) return;
     if (_connectedState == ConnectedState.connecting ||
         _connectedState == ConnectedState.reconnecting) {
       return;
@@ -514,6 +542,7 @@ class Blaze {
       _eventController.add(_ConnectionEvent.connect);
     } catch (e) {
       w('ws ping error: $e');
+      if (_stoppedForUpgrade || upgradeGate.isRequired) return;
       if (e is MixinApiError &&
           e.error != null &&
           e.error is MixinError &&
@@ -524,6 +553,12 @@ class Blaze {
       i('Triggering ERROR event: HTTP ping failed');
       _eventController.add(_ConnectionEvent.error);
     }
+  }
+
+  void stopForUpgrade() {
+    if (_stoppedForUpgrade) return;
+    _stoppedForUpgrade = true;
+    _disconnect();
   }
 
   void _onProxySettingChanged() {

--- a/lib/utils/mixin_api_client.dart
+++ b/lib/utils/mixin_api_client.dart
@@ -19,6 +19,31 @@ const kRequestTimeStampKey = 'requestTimeStamp';
 Future<String?> _userAgent = generateUserAgent();
 Future<String?> _deviceId = getDeviceId();
 
+class ApiUpgradeRequiredException implements Exception {
+  const ApiUpgradeRequiredException();
+
+  @override
+  String toString() => 'API upgrade required';
+}
+
+class ApiUpgradeGate {
+  bool _required = false;
+
+  bool get isRequired => _required;
+
+  bool require() {
+    if (_required) return false;
+    _required = true;
+    return true;
+  }
+
+  DioException error(RequestOptions options) => DioException(
+    requestOptions: options,
+    type: DioExceptionType.cancel,
+    error: const ApiUpgradeRequiredException(),
+  );
+}
+
 Client createClient({
   required String userId,
   required String sessionId,
@@ -26,6 +51,8 @@ Client createClient({
   // Hive didn't support multi isolate.
   required bool loginByPhoneNumber,
   List<Interceptor> interceptors = const [],
+  ApiUpgradeGate? upgradeGate,
+  void Function()? onUpgradeRequired,
 }) {
   final client = Client(
     userId: userId,
@@ -41,6 +68,23 @@ Client createClient({
     // httpLogLevel: HttpLogLevel.none,
     jsonDecodeCallback: jsonDecode,
     interceptors: [
+      if (upgradeGate != null)
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            if (upgradeGate.isRequired) {
+              handler.reject(upgradeGate.error(options));
+              return;
+            }
+            handler.next(options);
+          },
+          onError: (error, handler) {
+            final mixinError = error is MixinApiError ? error.error : null;
+            if (mixinError is MixinError && mixinError.code == oldVersion) {
+              if (upgradeGate.require()) onUpgradeRequired?.call();
+            }
+            handler.next(error);
+          },
+        ),
       ...interceptors,
       InterceptorsWrapper(
         onRequest: (options, handler) {

--- a/lib/workers/isolate_event.dart
+++ b/lib/workers/isolate_event.dart
@@ -5,6 +5,7 @@ import '../db/mixin_database.dart';
 enum MainIsolateEventType {
   reconnectBlaze,
   disconnectBlazeWithTime,
+  requireUpgrade,
   updateSelectedConversation,
   addAckJobs,
   addSessionAckJobs,
@@ -29,6 +30,8 @@ enum WorkerIsolateEventType {
 
   /// args: DioException
   onApiRequestedError,
+
+  onUpgradeRequired,
 
   /// args: [AttachmentRequest]
   requestDownloadAttachment,

--- a/lib/workers/job_queue.dart
+++ b/lib/workers/job_queue.dart
@@ -15,6 +15,7 @@ abstract class JobQueue<AddType, RunType> {
 
   @protected
   bool isRunning = false;
+  bool _stopped = false;
 
   @protected
   bool get enable => true;
@@ -34,21 +35,28 @@ abstract class JobQueue<AddType, RunType> {
   @protected
   bool isValid(RunType job);
 
-  void start() => unawaited(_run());
+  void start() {
+    if (_stopped) return;
+    unawaited(_run());
+  }
+
+  void stop() => _stopped = true;
 
   Future<void> add(AddType job) async {
+    if (_stopped) return;
     await insertJob(job);
+    if (_stopped) return;
     unawaited(_run());
   }
 
   Future<void> _run() async {
-    if (!enable) return;
+    if (_stopped || !enable) return;
     if (isRunning) return;
     isRunning = true;
 
-    while (true) {
+    while (!_stopped) {
       final list = await fetchJobs();
-      if (!isValid(list)) break;
+      if (_stopped || !isValid(list)) break;
       try {
         await run(list);
       } catch (err) {

--- a/lib/workers/message_worker_isolate.dart
+++ b/lib/workers/message_worker_isolate.dart
@@ -130,6 +130,10 @@ class _MessageProcessRunner {
   late Blaze blaze;
   late Sender _sender;
   late SignalProtocol signalProtocol;
+  final _upgradeGate = ApiUpgradeGate();
+  var _upgradeHandled = false;
+  var _blazeReady = false;
+  var _jobsReady = false;
 
   late SendingJob _sendingJob;
   late AckJob _ackJob;
@@ -167,6 +171,8 @@ class _MessageProcessRunner {
         ),
       ],
       loginByPhoneNumber: initParams.loginByPhoneNumber,
+      upgradeGate: _upgradeGate,
+      onUpgradeRequired: _onUpgradeRequired,
     )..configProxySetting(database.settingProperties);
 
     _ackJob = AckJob(database: database, client: client);
@@ -185,7 +191,10 @@ class _MessageProcessRunner {
       await generateUserAgent(),
       _ackJob,
       _floodJob,
+      upgradeGate: _upgradeGate,
+      onUpgradeRequired: _onUpgradeRequired,
     );
+    _blazeReady = true;
 
     blaze.connectedStateStream.listen((event) {
       _sendEventToMainIsolate(
@@ -203,6 +212,7 @@ class _MessageProcessRunner {
       sessionId,
       userId,
       database,
+      upgradeGate: _upgradeGate,
     );
 
     _sendingJob = SendingJob(
@@ -229,6 +239,8 @@ class _MessageProcessRunner {
       database: database,
       client: client,
     );
+    _jobsReady = true;
+    if (_upgradeGate.isRequired) _stopJobs();
 
     MigrateFtsJob(database: database);
     DeleteOldFtsRecordJob(database: database);
@@ -276,6 +288,30 @@ class _MessageProcessRunner {
       _syncInscriptionMessageJob,
     );
     _floodJob.start();
+  }
+
+  void _onUpgradeRequired() {
+    _upgradeGate.require();
+    if (_upgradeHandled) return;
+    _upgradeHandled = true;
+    if (_blazeReady) blaze.stopForUpgrade();
+    _stopJobs();
+    _sendEventToMainIsolate(WorkerIsolateEventType.onUpgradeRequired);
+  }
+
+  void _stopJobs() {
+    if (_jobsReady) {
+      _ackJob.stop();
+      _floodJob.stop();
+      _sendingJob.stop();
+      _sessionAckJob.stop();
+      _updateAssetJob.stop();
+      _updateTokenJob.stop();
+      _updateStickerJob.stop();
+      _syncInscriptionMessageJob.stop();
+    }
+    _nextExpiredMessageRunner?.cancel();
+    _nextExpiredMessageRunner = null;
   }
 
   Function(FloodMessage floodMessage)? getProcessFloodJob() =>
@@ -379,7 +415,10 @@ class _MessageProcessRunner {
         _decryptMessage?.conversationId = conversationId;
       case MainIsolateEventType.disconnectBlazeWithTime:
         blaze.waitSyncTime();
+      case MainIsolateEventType.requireUpgrade:
+        _onUpgradeRequired();
       case MainIsolateEventType.reconnectBlaze:
+        if (_upgradeGate.isRequired) return;
         i('message worker isolate: reconnect blaze');
         blaze.reconnect();
       case MainIsolateEventType.addAckJobs:
@@ -403,6 +442,7 @@ class _MessageProcessRunner {
   }
 
   void dispose() {
+    _stopJobs();
     blaze.dispose();
     database.dispose();
     jobSubscribers.forEach((subscription) => subscription.cancel());

--- a/lib/workers/sender.dart
+++ b/lib/workers/sender.dart
@@ -20,6 +20,7 @@ import '../db/mixin_database.dart' as db;
 import '../enum/message_category.dart';
 import '../utils/extension/extension.dart';
 import '../utils/logger.dart';
+import '../utils/mixin_api_client.dart';
 
 class Sender {
   Sender(
@@ -28,8 +29,9 @@ class Sender {
     this.client,
     this.sessionId,
     this.accountId,
-    this.database,
-  );
+    this.database, {
+    required this.upgradeGate,
+  });
 
   final SignalProtocol signalProtocol;
   final Blaze blaze;
@@ -37,8 +39,12 @@ class Sender {
   final String sessionId;
   final String accountId;
   final Database database;
+  final ApiUpgradeGate upgradeGate;
 
   Future<MessageResult> deliver(BlazeMessage blazeMessage) async {
+    if (upgradeGate.isRequired) {
+      throw const ApiUpgradeRequiredException();
+    }
     final params = blazeMessage.params as BlazeMessageParam;
     final cid = params.conversationId;
     if (cid != null) {
@@ -47,6 +53,9 @@ class Sender {
     }
     i('deliver blazeMessage: ${blazeMessage.id}');
     final bm = await blaze.sendMessage(blazeMessage);
+    if (upgradeGate.isRequired) {
+      throw const ApiUpgradeRequiredException();
+    }
     if (bm == null) {
       await _sleep(1);
       return deliver(blazeMessage);
@@ -75,7 +84,13 @@ class Sender {
   }
 
   Future<BlazeMessage?> signalKeysChannel(BlazeMessage blazeMessage) async {
+    if (upgradeGate.isRequired) {
+      throw const ApiUpgradeRequiredException();
+    }
     final bm = await blaze.sendMessage(blazeMessage);
+    if (upgradeGate.isRequired) {
+      throw const ApiUpgradeRequiredException();
+    }
     if (bm == null) {
       await _sleep(1);
       return signalKeysChannel(blazeMessage);

--- a/test/utils/mixin_api_client_test.dart
+++ b/test/utils/mixin_api_client_test.dart
@@ -1,0 +1,16 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_app/utils/mixin_api_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('upgrade gate latches once and creates a local error', () {
+    final gate = ApiUpgradeGate();
+    final options = RequestOptions(path: '/me');
+
+    expect(gate.isRequired, isFalse);
+    expect(gate.require(), isTrue);
+    expect(gate.require(), isFalse);
+    expect(gate.isRequired, isTrue);
+    expect(gate.error(options).error, isA<ApiUpgradeRequiredException>());
+  });
+}


### PR DESCRIPTION
## Summary
- latch authenticated Mixin API clients when the server returns `oldVersion` (10006)
- stop Blaze reconnects, worker queues, sender recursion, and periodic signal-key checks
- keep the existing upgrade screen and local session data while leaving CDN attachment transfers unchanged

## Root cause
The upgrade response only updated UI state. Running Blaze and worker retry loops continued sending requests, which could repeatedly reconnect from the same IP.

## Behavior
After the upgrade signal, in-flight requests may finish, but new Mixin API requests and retries are rejected locally. The in-memory latch resets on process restart.

## Validation
- `flutter test test/utils/mixin_api_client_test.dart`
- Dart analysis for the changed files