### PR TITLE
fix: narrow bare 7000 recognition

### DIFF
--- a/lib/utils/reg_exp_utils.dart
+++ b/lib/utils/reg_exp_utils.dart
@@ -3,6 +3,8 @@ final mentionNumberRegExp = RegExp(r'@(\d{4,})');
 final uriRegExp = RegExp(
   r'\b[a-zA-z+]+:(?://)?[\w-]+(?:\.[\w-]+)*(?:[\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?\b/?',
 );
-final botNumberRegExp = RegExp(r'(?<!\d)7000(?:\d{6})?(?!\d)');
+final botNumberRegExp = RegExp(
+  r'(?<!\d)7000\d{6}(?!\d)|(?<=@)7000(?!\d)|(?<!\S)7000(?!\S)',
+);
 final mailRegExp = RegExp(r'\b[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}\b');
 final numberRegExp = RegExp(r'^\d{4,}$');

--- a/test/account/send_message_helper_test.dart
+++ b/test/account/send_message_helper_test.dart
@@ -1,0 +1,134 @@
+@TestOn('linux || mac-os')
+library;
+
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_app/account/send_message_helper.dart';
+import 'package:flutter_app/db/dao/job_dao.dart';
+import 'package:flutter_app/db/database.dart';
+import 'package:flutter_app/db/fts_database.dart';
+import 'package:flutter_app/db/mixin_database.dart';
+import 'package:flutter_app/enum/encrypt_category.dart';
+import 'package:flutter_app/utils/attachment/attachment_util.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart'
+    hide Conversation, User;
+
+void main() {
+  late Database database;
+  late SendMessageHelper helper;
+  late List<Job> jobs;
+
+  setUp(() async {
+    database = Database(
+      MixinDatabase(NativeDatabase.memory()),
+      FtsDatabase(NativeDatabase.memory()),
+    );
+    await database.mixinDatabase
+        .into(database.mixinDatabase.users)
+        .insert(const User(userId: 'sender', identityNumber: '1000'));
+    await database.mixinDatabase
+        .into(database.mixinDatabase.conversations)
+        .insert(
+          Conversation(
+            conversationId: 'conversation',
+            ownerId: 'sender',
+            category: ConversationCategory.contact,
+            createdAt: DateTime.utc(2026),
+            status: ConversationStatus.success,
+          ),
+        );
+    await database.mixinDatabase
+        .into(database.mixinDatabase.users)
+        .insert(const User(userId: 'bare-bot', identityNumber: '7000'));
+    await database.mixinDatabase
+        .into(database.mixinDatabase.users)
+        .insert(
+          const User(userId: 'full-bot', identityNumber: '7000105415'),
+        );
+    await database.mixinDatabase
+        .into(database.mixinDatabase.users)
+        .insert(
+          const User(userId: 'unjoined-bot', identityNumber: '7000999999'),
+        );
+    await database.mixinDatabase
+        .into(database.mixinDatabase.participants)
+        .insert(
+          Participant(
+            conversationId: 'conversation',
+            userId: 'bare-bot',
+            createdAt: DateTime.utc(2026),
+          ),
+        );
+    await database.mixinDatabase
+        .into(database.mixinDatabase.participants)
+        .insert(
+          Participant(
+            conversationId: 'conversation',
+            userId: 'full-bot',
+            createdAt: DateTime.utc(2026),
+          ),
+        );
+
+    jobs = [];
+    helper = SendMessageHelper(database, _UnusedAttachmentUtil(), jobs.add);
+  });
+
+  tearDown(() async {
+    await pumpEventQueue();
+    await database.dispose();
+  });
+
+  const cases = <String, String?>{
+    '@7000 hello': 'bare-bot',
+    '@7000 ': 'bare-bot',
+    '@7000  hello': 'bare-bot',
+    '@7000105415 hello': 'full-bot',
+    '@7000105415 ': 'full-bot',
+    '@7000 @7000105415 hello': 'bare-bot',
+    '@7000105415 @7000 hello': 'full-bot',
+    '@7000': null,
+    '@7000U hello': null,
+    '@7000hello': null,
+    '@7000\thello': null,
+    '@7000\nhello': null,
+    '@7000\u00a0hello': null,
+    '@7000, hello': null,
+    '@7000。hello': null,
+    '@7000105415U hello': null,
+    '@7000105415hello': null,
+    '@7000105415, hello': null,
+    '@70001 hello': null,
+    '@70001054151 hello': null,
+    'hello @7000 hello': null,
+    ' @7000 hello': null,
+    '@7000U @7000 hello': null,
+    '@70001 @7000 hello': null,
+    '@7000999999 hello': null,
+  };
+
+  test('routes configured bot mentions', () async {
+    for (final entry in cases.entries) {
+      await helper.sendTextMessage(
+        'conversation',
+        'sender',
+        EncryptCategory.encrypted,
+        entry.key,
+      );
+
+      final job = jobs.removeLast();
+      final payload = jsonDecode(job.blazeMessage!) as Map<String, dynamic>;
+      expect(
+        payload[JobDao.recipientIdKey],
+        entry.value,
+        reason: entry.key,
+      );
+    }
+  });
+}
+
+class _UnusedAttachmentUtil implements AttachmentUtil {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/regex_test.dart
+++ b/test/regex_test.dart
@@ -12,6 +12,10 @@ void match(RegExp regExp, String text, String uri) {
 
 void main() {
   final bigText = List.generate(1024 * 64, (index) => 'a').join();
+  final botNumberNonMatchText = List.generate(
+    1024 * 8,
+    (index) => index.isEven ? '7000U' : '70001054151',
+  ).join();
 
   group('uri', () {
     test('speed', () {
@@ -76,7 +80,9 @@ void main() {
   group('bot number', () {
     test('speed', () {
       final timer = Stopwatch()..start();
-      final matches = botNumberRegExp.allMatches(bigText).toList();
+      final matches = botNumberRegExp
+          .allMatches(botNumberNonMatchText)
+          .toList();
       timer.stop();
 
       expect(timer.elapsedMilliseconds, lessThan(10));
@@ -87,27 +93,58 @@ void main() {
       }
     });
 
-    const botNumbers = ['7000', '7000105415'];
+    const cases = <String, List<String>>{
+      '7000105415': ['7000105415'],
+      'foo7000105415bar': ['7000105415'],
+      '福7000105415报': ['7000105415'],
+      '@7000105415': ['7000105415'],
+      '@7000105415U': ['7000105415'],
+      '7000': ['7000'],
+      ' 7000 ': ['7000'],
+      '\t7000\t': ['7000'],
+      '\n7000\r\n': ['7000'],
+      '\u30007000\u00a0': ['7000'],
+      '@7000': ['7000'],
+      '@7000U': ['7000'],
+      '@7000hello': ['7000'],
+      'hello@7000world': ['7000'],
+      '中文@7000中文': ['7000'],
+      '@7000，': ['7000'],
+      '@@7000': ['7000'],
+      '@7000U 7000 7000105415 @7000': [
+        '7000',
+        '7000',
+        '7000105415',
+        '7000',
+      ],
+      '7000U': [],
+      'U7000': [],
+      'foo7000bar': [],
+      '转7000': [],
+      '7000转': [],
+      '_7000': [],
+      '7000_': [],
+      '(7000)': [],
+      ':7000,': [],
+      '7000。': [],
+      '7000\u200b': [],
+      '70001': [],
+      '@70001': [],
+      '17000105415': [],
+      '70001054151': [],
+      '@70001054151': [],
+    };
 
-    test('syntax', () {
-      for (final botNumber in botNumbers) {
-        match(botNumberRegExp, botNumber, botNumber);
-      }
-    });
-
-    test('accuracy', () {
-      for (final botNumber in botNumbers) {
-        match(botNumberRegExp, '($botNumber)', botNumber);
-        match(botNumberRegExp, 'foo${botNumber}bar', botNumber);
-        match(botNumberRegExp, '福$botNumber报', botNumber);
-        match(botNumberRegExp, ':$botNumber,', botNumber);
-        match(botNumberRegExp, '：$botNumber。', botNumber);
-      }
-    });
-
-    test('does not match partial numbers', () {
-      for (final text in ['70001', '70001054151']) {
-        expect(botNumberRegExp.hasMatch(text), isFalse, reason: text);
+    test('matches configured bot-number cases', () {
+      for (final entry in cases.entries) {
+        expect(
+          botNumberRegExp
+              .allMatches(entry.key)
+              .map((match) => match[0])
+              .toList(),
+          entry.value,
+          reason: entry.key,
+        );
       }
     });
   });


### PR DESCRIPTION
## Summary

- Restrict bare 7000 recognition to standalone or whitespace-delimited text.
- Preserve ten-digit bot-number recognition and explicit @7000 recognition.
- Cover matching and routing behavior with data-driven regression cases.

## Testing

- flutter test --no-pub test/regex_test.dart test/account/send_message_helper_test.dart
- flutter analyze --no-pub lib/utils/reg_exp_utils.dart lib/account/send_message_helper.dart test/regex_test.dart test/account/send_message_helper_test.dart