### PR TITLE
Optimize expired message cleanup

### DIFF
--- a/lib/db/dao/expired_message_dao.g.dart
+++ b/lib/db/dao/expired_message_dao.g.dart
@@ -46,7 +46,7 @@ mixin _$ExpiredMessageDaoMixin on DatabaseAccessor<MixinDatabase> {
   InscriptionItems get inscriptionItems => attachedDatabase.inscriptionItems;
   Selectable<ExpiredMessage> getExpiredMessages(int? currentTime) {
     return customSelect(
-      'SELECT * FROM expired_messages WHERE expire_at <= ?1 ORDER BY expire_at ASC',
+      'SELECT * FROM expired_messages WHERE expire_at <= ?1 ORDER BY expire_at ASC LIMIT 100',
       variables: [Variable<int>(currentTime)],
       readsFrom: {expiredMessages},
     ).asyncMap(expiredMessages.mapFromRow);

--- a/lib/db/mixin_database.dart
+++ b/lib/db/mixin_database.dart
@@ -99,7 +99,7 @@ class MixinDatabase extends _$MixinDatabase {
   MixinDatabase(super.e);
 
   @override
-  int get schemaVersion => 28;
+  int get schemaVersion => 29;
 
   final eventBus = DataBaseEventBus.instance;
 
@@ -277,6 +277,9 @@ class MixinDatabase extends _$MixinDatabase {
       }
       if (from <= 27) {
         await _addColumnIfNotExists(m, tokens, tokens.precision);
+      }
+      if (from <= 28) {
+        await m.createIndex(indexExpiredMessagesExpireAt);
       }
     },
     beforeOpen: (details) async {

--- a/lib/db/mixin_database.g.dart
+++ b/lib/db/mixin_database.g.dart
@@ -18884,6 +18884,10 @@ abstract class _$MixinDatabase extends GeneratedDatabase {
     'index_tokens_collection_hash',
     'CREATE INDEX IF NOT EXISTS index_tokens_collection_hash ON tokens (collection_hash)',
   );
+  late final Index indexExpiredMessagesExpireAt = Index(
+    'index_expired_messages_expire_at',
+    'CREATE INDEX IF NOT EXISTS index_expired_messages_expire_at ON expired_messages (expire_at) WHERE expire_at IS NOT NULL',
+  );
   late final AddressDao addressDao = AddressDao(this as MixinDatabase);
   late final AppDao appDao = AppDao(this as MixinDatabase);
   late final AssetDao assetDao = AssetDao(this as MixinDatabase);
@@ -19447,6 +19451,7 @@ abstract class _$MixinDatabase extends GeneratedDatabase {
     indexMessagesConversationIdQuoteMessageId,
     indexTokensKernelAssetId,
     indexTokensCollectionHash,
+    indexExpiredMessagesExpireAt,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([

--- a/lib/db/moor/dao/expired_message.drift
+++ b/lib/db/moor/dao/expired_message.drift
@@ -1,7 +1,7 @@
 import '../mixin.drift';
 
 getExpiredMessages:
-SELECT * FROM expired_messages WHERE expire_at <= :currentTime ORDER BY expire_at ASC;
+SELECT * FROM expired_messages WHERE expire_at <= :currentTime ORDER BY expire_at ASC LIMIT 100;
 
 getFirstExpiredMessage:
 SELECT * FROM expired_messages WHERE expire_at IS NOT NULL ORDER BY expire_at ASC LIMIT 1;

--- a/lib/db/moor/mixin.drift
+++ b/lib/db/moor/mixin.drift
@@ -153,3 +153,4 @@ CREATE INDEX IF NOT EXISTS index_message_conversation_id_status_user_id ON messa
 CREATE INDEX IF NOT EXISTS index_messages_conversation_id_quote_message_id ON messages(conversation_id, quote_message_id);
 CREATE INDEX IF NOT EXISTS index_tokens_kernel_asset_id ON tokens(kernel_asset_id);
 CREATE INDEX IF NOT EXISTS index_tokens_collection_hash ON tokens(collection_hash);
+CREATE INDEX IF NOT EXISTS index_expired_messages_expire_at ON expired_messages(expire_at) WHERE expire_at IS NOT NULL;

--- a/test/db/expired_message_dao_test.dart
+++ b/test/db/expired_message_dao_test.dart
@@ -1,0 +1,104 @@
+@TestOn('linux || mac-os')
+library;
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_app/db/mixin_database.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _indexName = 'index_expired_messages_expire_at';
+
+void main() {
+  test('creates a partial expire_at index for new databases', () async {
+    final database = MixinDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+
+    expect(
+      await _indexSql(database),
+      allOf(
+        contains('ON expired_messages (expire_at)'),
+        contains('WHERE expire_at IS NOT NULL'),
+      ),
+    );
+  });
+
+  test('adds the partial expire_at index when migrating from v28', () async {
+    final database = MixinDatabase(
+      NativeDatabase.memory(
+        setup: (rawDatabase) {
+          rawDatabase
+            ..execute('''
+              CREATE TABLE expired_messages (
+                message_id TEXT NOT NULL,
+                expire_in INTEGER NOT NULL,
+                expire_at INTEGER,
+                PRIMARY KEY(message_id)
+              )
+            ''')
+            ..userVersion = 28;
+        },
+      ),
+    );
+    addTearDown(database.close);
+
+    expect(
+      await _indexSql(database),
+      allOf(
+        contains('ON expired_messages (expire_at)'),
+        contains('WHERE expire_at IS NOT NULL'),
+      ),
+    );
+  });
+
+  test('loads expired messages in bounded batches', () async {
+    final database = MixinDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+
+    await database.batch((batch) {
+      batch.insertAll(database.expiredMessages, [
+        for (var index = 0; index < 101; index++)
+          ExpiredMessage(
+            messageId: 'expired-$index',
+            expireIn: 0,
+            expireAt: index,
+          ),
+        const ExpiredMessage(
+          messageId: 'not-started',
+          expireIn: 0,
+        ),
+        ExpiredMessage(
+          messageId: 'future',
+          expireIn: 0,
+          expireAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600,
+        ),
+      ]);
+    });
+
+    final firstBatch = await database.expiredMessageDao
+        .getCurrentExpiredMessages();
+    expect(firstBatch, hasLength(100));
+    expect(firstBatch.first.messageId, 'expired-0');
+    expect(firstBatch.last.messageId, 'expired-99');
+
+    await database.expiredMessageDao.deleteByMessageIds(
+      firstBatch.map((message) => message.messageId).toList(),
+    );
+
+    final secondBatch = await database.expiredMessageDao
+        .getCurrentExpiredMessages();
+    expect(secondBatch.map((message) => message.messageId), ['expired-100']);
+  });
+}
+
+Future<String> _indexSql(MixinDatabase database) async {
+  final row = await database
+      .customSelect(
+        'SELECT sql FROM sqlite_master WHERE type = ? AND name = ?',
+        variables: [
+          const Variable('index'),
+          const Variable(_indexName),
+        ],
+      )
+      .getSingle();
+  return row.read<String>('sql');
+}


### PR DESCRIPTION
## Summary
- add a partial `expire_at` index for `expired_messages` and migrate schema v28 databases
- limit each expired-message cleanup query to the earliest 100 due records while retaining the existing timer continuation
- cover new database creation, v28 migration, and 100 + 1 batch behavior

## Validation
- `dart run build_runner build`
- `flutter test test/db`
- targeted Dart analysis for the affected database source and regression test