### PR TITLE
Revert "fix: recognize both bot identity number formats"

### DIFF
--- a/lib/account/send_message_helper.dart
+++ b/lib/account/send_message_helper.dart
@@ -92,7 +92,7 @@ class SendMessageHelper {
 
     if (content.startsWith('@7000')) {
       final botNumber = botNumberRegExp.firstMatch(content)?[0];
-      if (botNumber != null && content.startsWith('@$botNumber ')) {
+      if (botNumber != null && botNumber.isNotEmpty) {
         recipientId = await _participantDao
             .userIdByIdentityNumber(conversationId, botNumber)
             .getSingleOrNull();

--- a/lib/utils/reg_exp_utils.dart
+++ b/lib/utils/reg_exp_utils.dart
@@ -3,6 +3,6 @@ final mentionNumberRegExp = RegExp(r'@(\d{4,})');
 final uriRegExp = RegExp(
   r'\b[a-zA-z+]+:(?://)?[\w-]+(?:\.[\w-]+)*(?:[\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?\b/?',
 );
-final botNumberRegExp = RegExp(r'(?<!\d)7000(?:\d{6})?(?!\d)');
+final botNumberRegExp = RegExp(r'(?<!\d)7000\d{6}(?!\d)');
 final mailRegExp = RegExp(r'\b[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}\b');
 final numberRegExp = RegExp(r'^\d{4,}$');

--- a/test/regex_test.dart
+++ b/test/regex_test.dart
@@ -87,30 +87,20 @@ void main() {
       }
     });
 
-    const botNumbers = ['7000', '7000105415'];
+    const botNumber = 7000123456;
 
     test('syntax', () {
-      for (final botNumber in botNumbers) {
-        match(botNumberRegExp, botNumber, botNumber);
-      }
+      match(botNumberRegExp, '$botNumber', '$botNumber');
     });
 
     test('accuracy', () {
-      for (final botNumber in botNumbers) {
-        match(botNumberRegExp, '($botNumber)', botNumber);
-        match(botNumberRegExp, 'foo${botNumber}bar', botNumber);
-        match(botNumberRegExp, '福$botNumber报', botNumber);
-        match(botNumberRegExp, ':$botNumber,', botNumber);
-        match(botNumberRegExp, '：$botNumber。', botNumber);
-      }
+      match(botNumberRegExp, '($botNumber)', '$botNumber');
+      match(botNumberRegExp, 'foo${botNumber}bar', '$botNumber');
+      match(botNumberRegExp, '福$botNumber报', '$botNumber');
+      match(botNumberRegExp, ':$botNumber,', '$botNumber');
+      match(botNumberRegExp, '：$botNumber。', '$botNumber');
     });
-
-    test('does not match partial numbers', () {
-      for (final text in ['70001', '70001054151']) {
-        expect(botNumberRegExp.hasMatch(text), isFalse, reason: text);
-      }
-    });
-  });
+  }, skip: true);
 
   group('mail', () {
     test('speed', () {


### PR DESCRIPTION
## Summary

- Revert the bot identity-number recognition changes from #2019.
- Restore recognition of ten-digit bot identity numbers only.
- Restore the previous explicit bot routing condition.

## Testing

- Ran the affected regex tests with skipped cases enabled.
- Ran static analysis for the affected files.