### PR TITLE
Fix Flutter 3.47 analyzer issues

### DIFF
--- a/lib/account/account_server.dart
+++ b/lib/account/account_server.dart
@@ -1634,7 +1634,7 @@ class AccountServer {
     try {
       final user = await client.userApi.getUserById(id);
       await _injector.insertUpdateUsers([user.data]);
-      return database.appDao.findAppById(id);
+      return await database.appDao.findAppById(id);
     } catch (error, stackTrace) {
       d('get app and check user error: $error, $stackTrace');
       return null;

--- a/lib/widgets/media_image_pipeline.dart
+++ b/lib/widgets/media_image_pipeline.dart
@@ -140,7 +140,7 @@ class ProxyNetworkImage extends ImageProvider<ProxyNetworkImage> {
       final bytes = normalizeGifBytesIfNeeded(
         await downloadImageBytes(key.url, proxyConfig: key.proxyConfig),
       );
-      return decode(await ui.ImmutableBuffer.fromUint8List(bytes));
+      return await decode(await ui.ImmutableBuffer.fromUint8List(bytes));
     } catch (_) {
       scheduleMicrotask(() {
         PaintingBinding.instance.imageCache.evict(key);

--- a/lib/widgets/menu.dart
+++ b/lib/widgets/menu.dart
@@ -664,7 +664,8 @@ extension on SingleActivator {
   String stringRepresentation() => [
     if (control) 'Ctrl',
     if (alt) 'Alt',
-    if (meta) defaultTargetPlatform == TargetPlatform.macOS ? 'Cmd' : 'Meta',
+    if (meta)
+      if (defaultTargetPlatform == TargetPlatform.macOS) 'Cmd' else 'Meta',
     if (shift) 'Shift',
     trigger.keyLabel,
   ].join('+');

--- a/lib/workers/injector.dart
+++ b/lib/workers/injector.dart
@@ -174,10 +174,10 @@ class Injector {
     try {
       if (ids.length == 1) {
         final response = await client.userApi.getUserById(ids.first);
-        return insertUpdateUsers([response.data]);
+        return await insertUpdateUsers([response.data]);
       } else {
         final response = await client.userApi.getUsers(ids);
-        return insertUpdateUsers(response.data);
+        return await insertUpdateUsers(response.data);
       }
     } catch (e, s) {
       w('_fetchUsers error $e, stack: $s');


### PR DESCRIPTION
## Summary
- await asynchronous database and image decoding results inside existing error-handling blocks
- replace the platform-label conditional expression with collection `if` elements accepted by Flutter 3.47

## Validation
- `dart format --set-exit-if-changed` on the four changed files
- `dart analyze --fatal-infos`
- `flutter test test/widgets/media_image_pipeline_test.dart`