### PR TITLE
Fix expired message scheduling after worker restart

### DIFF
--- a/lib/db/dao/expired_message_dao.dart
+++ b/lib/db/dao/expired_message_dao.dart
@@ -52,6 +52,15 @@ class ExpiredMessageDao extends DatabaseAccessor<MixinDatabase>
     DataBaseEventBus.instance.updateExpiredMessageTable();
   }
 
+  @override
+  Future<int> updateMessageExpireAt(int? expireAt, String messageId) async {
+    final updated = await super.updateMessageExpireAt(expireAt, messageId);
+    if (updated > 0) {
+      DataBaseEventBus.instance.updateExpiredMessageTable();
+    }
+    return updated;
+  }
+
   Future<Map<String, int?>> getMessageExpireAt(List<String> messageIds) async {
     final messages = await (select(
       db.expiredMessages,

--- a/lib/workers/message_worker_isolate.dart
+++ b/lib/workers/message_worker_isolate.dart
@@ -364,7 +364,6 @@ class _MessageProcessRunner {
     d('_scheduleExpiredJob');
     final messages = await database.expiredMessageDao
         .getCurrentExpiredMessages();
-    if (messages.isEmpty) return;
 
     for (final em in messages) {
       // cancel attachment download.
@@ -397,14 +396,13 @@ class _MessageProcessRunner {
       _nextExpiredMessageRunner = null;
       return;
     }
+    final delaySeconds =
+        firstExpiredMessage.expireAt! -
+        DateTime.now().millisecondsSinceEpoch ~/ 1000;
     _nextExpiredMessageRunner?.cancel();
     _nextExpiredMessageRunner = Timer(
-      Duration(
-        seconds:
-            firstExpiredMessage.expireAt! -
-            DateTime.now().millisecondsSinceEpoch ~/ 1000,
-      ),
-      _scheduleExpiredJob,
+      Duration(seconds: delaySeconds > 0 ? delaySeconds : 0),
+      DataBaseEventBus.instance.updateExpiredMessageTable,
     );
   }
 

--- a/lib/workers/message_worker_isolate.dart
+++ b/lib/workers/message_worker_isolate.dart
@@ -8,6 +8,7 @@ import 'package:ansicolor/ansicolor.dart';
 import 'package:dio/dio.dart';
 import 'package:ed25519_edwards/ed25519_edwards.dart' as ed;
 import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
 import 'package:rhttp/rhttp.dart';
@@ -16,6 +17,7 @@ import 'package:stream_channel/isolate_channel.dart';
 
 import '../blaze/blaze.dart';
 import '../crypto/signal/signal_protocol.dart';
+import '../db/dao/expired_message_dao.dart';
 import '../db/database.dart';
 import '../db/database_event_bus.dart';
 import '../db/fts_database.dart';
@@ -101,6 +103,33 @@ Future<void> startMessageProcessIsolate(IsolateInitParams params) async {
 }
 
 final Map<String, MessageStatus> pendingMessageStatusMap = {};
+
+@visibleForTesting
+Future<Timer?> runExpiredMessageScheduler({
+  required ExpiredMessageDao expiredMessageDao,
+  required Future<void> Function(ExpiredMessage message) expireMessage,
+  required void Function() onTimer,
+  Timer? previousTimer,
+}) async {
+  final messages = await expiredMessageDao.getCurrentExpiredMessages();
+  for (final message in messages) {
+    await expireMessage(message);
+  }
+
+  final firstExpiredMessage = await expiredMessageDao
+      .getFirstExpiredMessage()
+      .getSingleOrNull();
+  previousTimer?.cancel();
+  if (firstExpiredMessage == null) return null;
+
+  final delaySeconds =
+      firstExpiredMessage.expireAt! -
+      DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  return Timer(
+    Duration(seconds: delaySeconds > 0 ? delaySeconds : 0),
+    onTimer,
+  );
+}
 
 class _MessageProcessRunner {
   _MessageProcessRunner({
@@ -362,47 +391,32 @@ class _MessageProcessRunner {
 
   Future<void> _scheduleExpiredJob() async {
     d('_scheduleExpiredJob');
-    final messages = await database.expiredMessageDao
-        .getCurrentExpiredMessages();
-
-    for (final em in messages) {
-      // cancel attachment download.
-      final message = await database.messageDao.findMessageByMessageId(
-        em.messageId,
-      );
-      if (message == null) {
-        e('message is null, messageId: ${em.messageId} ${em.expireAt}');
-        await database.expiredMessageDao.deleteByMessageId(em.messageId);
-        continue;
-      }
-      await database.messageDao.deleteMessage(
-        message.conversationId,
-        em.messageId,
-      );
-      unawaited(database.ftsDatabase.deleteByMessageId(em.messageId));
-      if (message.category.isAttachment || message.category.isTranscript) {
-        _sendEventToMainIsolate(
-          WorkerIsolateEventType.requestDownloadAttachment,
-          AttachmentDeleteRequest(message: message),
+    _nextExpiredMessageRunner = await runExpiredMessageScheduler(
+      expiredMessageDao: database.expiredMessageDao,
+      previousTimer: _nextExpiredMessageRunner,
+      onTimer: DataBaseEventBus.instance.updateExpiredMessageTable,
+      expireMessage: (em) async {
+        // cancel attachment download.
+        final message = await database.messageDao.findMessageByMessageId(
+          em.messageId,
         );
-      }
-    }
-
-    final firstExpiredMessage = await database.expiredMessageDao
-        .getFirstExpiredMessage()
-        .getSingleOrNull();
-    if (firstExpiredMessage == null) {
-      _nextExpiredMessageRunner?.cancel();
-      _nextExpiredMessageRunner = null;
-      return;
-    }
-    final delaySeconds =
-        firstExpiredMessage.expireAt! -
-        DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    _nextExpiredMessageRunner?.cancel();
-    _nextExpiredMessageRunner = Timer(
-      Duration(seconds: delaySeconds > 0 ? delaySeconds : 0),
-      DataBaseEventBus.instance.updateExpiredMessageTable,
+        if (message == null) {
+          e('message is null, messageId: ${em.messageId} ${em.expireAt}');
+          await database.expiredMessageDao.deleteByMessageId(em.messageId);
+          return;
+        }
+        await database.messageDao.deleteMessage(
+          message.conversationId,
+          em.messageId,
+        );
+        unawaited(database.ftsDatabase.deleteByMessageId(em.messageId));
+        if (message.category.isAttachment || message.category.isTranscript) {
+          _sendEventToMainIsolate(
+            WorkerIsolateEventType.requestDownloadAttachment,
+            AttachmentDeleteRequest(message: message),
+          );
+        }
+      },
     );
   }
 

--- a/test/db/expired_message_dao_test.dart
+++ b/test/db/expired_message_dao_test.dart
@@ -1,14 +1,20 @@
 @TestOn('linux || mac-os')
 library;
 
+import 'dart:async';
+
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
+import 'package:flutter_app/db/database_event_bus.dart';
 import 'package:flutter_app/db/mixin_database.dart';
+import 'package:flutter_app/utils/event_bus.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 const _indexName = 'index_expired_messages_expire_at';
 
 void main() {
+  setUpAll(EventBus.initialize);
+
   test('creates a partial expire_at index for new databases', () async {
     final database = MixinDatabase(NativeDatabase.memory());
     addTearDown(database.close);
@@ -87,6 +93,33 @@ void main() {
     final secondBatch = await database.expiredMessageDao
         .getCurrentExpiredMessages();
     expect(secondBatch.map((message) => message.messageId), ['expired-100']);
+  });
+
+  test('notifies the scheduler when an expiration time is set', () async {
+    final database = MixinDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+
+    await database.expiredMessageDao.insert(
+      messageId: 'pending-expiration',
+      expireIn: 60,
+    );
+
+    final notified = Completer<void>();
+    final subscription = DataBaseEventBus
+        .instance
+        .updateExpiredMessageTableStream
+        .listen((_) {
+          if (!notified.isCompleted) notified.complete();
+        });
+    addTearDown(subscription.cancel);
+
+    final updated = await database.expiredMessageDao.updateMessageExpireAt(
+      DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60,
+      'pending-expiration',
+    );
+
+    expect(updated, 1);
+    await notified.future.timeout(const Duration(seconds: 1));
   });
 }
 

--- a/test/workers/message_worker_isolate_test.dart
+++ b/test/workers/message_worker_isolate_test.dart
@@ -1,0 +1,82 @@
+@TestOn('linux || mac-os')
+library;
+
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter_app/db/database_event_bus.dart';
+import 'package:flutter_app/db/mixin_database.dart';
+import 'package:flutter_app/utils/event_bus.dart';
+import 'package:flutter_app/utils/extension/extension.dart';
+import 'package:flutter_app/workers/message_worker_isolate.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  setUpAll(EventBus.initialize);
+
+  test(
+    'rebuilds a future expiration timer through the worker event queue',
+    () async {
+      final database = MixinDatabase(NativeDatabase.memory());
+      addTearDown(database.close);
+
+      await database.expiredMessageDao.insert(
+        messageId: 'future-expiration',
+        expireIn: 1,
+        expireAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3,
+      );
+
+      Timer? timer;
+      var runs = 0;
+      final timerScheduled = Completer<void>();
+      final messageExpired = Completer<void>();
+      final cleanupRunFinished = Completer<void>();
+
+      Future<void> schedule() async {
+        timer = await runExpiredMessageScheduler(
+          expiredMessageDao: database.expiredMessageDao,
+          previousTimer: timer,
+          onTimer: DataBaseEventBus.instance.updateExpiredMessageTable,
+          expireMessage: (message) async {
+            await database.expiredMessageDao.deleteByMessageId(
+              message.messageId,
+            );
+            if (!messageExpired.isCompleted) messageExpired.complete();
+          },
+        );
+        runs += 1;
+        if (runs == 1 && !timerScheduled.isCompleted) {
+          timerScheduled.complete();
+        }
+        if (runs == 2 && !cleanupRunFinished.isCompleted) {
+          cleanupRunFinished.complete();
+        }
+      }
+
+      final subscription = DataBaseEventBus
+          .instance
+          .updateExpiredMessageTableStream
+          .startWith(null)
+          .asyncBufferMap((_) => schedule())
+          .listen((_) {});
+      addTearDown(() async {
+        await subscription.cancel();
+        timer?.cancel();
+      });
+
+      await timerScheduled.future.timeout(const Duration(seconds: 1));
+      expect(timer, isNotNull);
+
+      await messageExpired.future.timeout(const Duration(seconds: 5));
+      await cleanupRunFinished.future.timeout(const Duration(seconds: 1));
+      expect(runs, greaterThanOrEqualTo(2));
+      expect(
+        await database.expiredMessageDao
+            .getFirstExpiredMessage()
+            .getSingleOrNull(),
+        isNull,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Rebuild the next expiration timer even when no messages are currently expired.
- Trigger rescheduling when a message receives its expiration timestamp.
- Route timer wakeups through the existing database event queue.

## Testing

- Ran the full Flutter test suite.
- Ran affected analyzer checks.