### PR TITLE
fix: skip empty expiration reschedules

### DIFF
--- a/lib/db/dao/expired_message_dao.dart
+++ b/lib/db/dao/expired_message_dao.dart
@@ -46,10 +46,16 @@ class ExpiredMessageDao extends DatabaseAccessor<MixinDatabase>
         .toList(growable: false)
         .slices(kMarkLimit);
     final now = DateTime.now().millisecondsSinceEpoch / 1000;
+    var updated = 0;
     for (final ids in chunkedMessageIds) {
-      await _markExpiredMessageRead(now, (em) => em.messageId.isIn(ids));
+      updated += await _markExpiredMessageRead(
+        now,
+        (em) => em.messageId.isIn(ids),
+      );
     }
-    DataBaseEventBus.instance.updateExpiredMessageTable();
+    if (updated > 0) {
+      DataBaseEventBus.instance.updateExpiredMessageTable();
+    }
   }
 
   @override

--- a/test/db/expired_message_dao_test.dart
+++ b/test/db/expired_message_dao_test.dart
@@ -121,6 +121,22 @@ void main() {
     expect(updated, 1);
     await notified.future.timeout(const Duration(seconds: 1));
   });
+
+  test('does not notify the scheduler when reading a normal message', () async {
+    final database = MixinDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+
+    var notified = false;
+    final subscription = DataBaseEventBus
+        .instance
+        .updateExpiredMessageTableStream
+        .listen((_) => notified = true);
+    addTearDown(subscription.cancel);
+
+    await database.expiredMessageDao.onMessageRead(['normal-message']);
+
+    expect(notified, isFalse);
+  });
 }
 
 Future<String> _indexSql(MixinDatabase database) async {


### PR DESCRIPTION
## Summary
- notify the expiration scheduler only when marking a read message changes a persisted expiration deadline
- cover normal-message reads without an expiration reschedule

## Testing
- flutter test test/db/expired_message_dao_test.dart
- dart analyze --fatal-infos lib/db/dao/expired_message_dao.dart test/db/expired_message_dao_test.dart