### PR TITLE
Fix chat search closing after conversation switch

### DIFF
--- a/lib/ui/home/chat/chat_page.dart
+++ b/lib/ui/home/chat/chat_page.dart
@@ -113,7 +113,6 @@ class ChatPage extends HookConsumerWidget {
             blinkNotifier: context.read<BlinkNotifier>(),
             scrollCoordinator: context.read<ChatScrollCoordinator>(),
             messageController: context.read<MessageController>(),
-            chatSideNotifier: context.read<ChatSideNotifier>(),
           ),
         ),
         Provider.value(value: pinMessageState),

--- a/lib/ui/home/chat/message_jump.dart
+++ b/lib/ui/home/chat/message_jump.dart
@@ -13,19 +13,17 @@ class ChatTimelineLocation {
     required BlinkNotifier blinkNotifier,
     required ChatScrollCoordinator scrollCoordinator,
     required MessageController messageController,
-    required ChatSideNotifier chatSideNotifier,
   }) : _blinkNotifier = blinkNotifier,
        _scrollCoordinator = scrollCoordinator,
-       _messageController = messageController,
-       _chatSideNotifier = chatSideNotifier;
+       _messageController = messageController;
 
   final BlinkNotifier _blinkNotifier;
   final ChatScrollCoordinator _scrollCoordinator;
   final MessageController _messageController;
-  final ChatSideNotifier _chatSideNotifier;
 
   Future<void> jumpToMessage(
     String messageId, {
+    required ChatSideNotifier chatSideNotifier,
     String? sourceMessageId,
     bool closeSideAfterJump = false,
     bool chatSideRouteMode = false,
@@ -44,7 +42,11 @@ class ChatTimelineLocation {
     );
     if (handled) {
       _blinkNotifier.blinkByMessageId(messageId);
-      _closeSideIfNeeded(closeSideAfterJump, chatSideRouteMode);
+      _closeSideIfNeeded(
+        closeSideAfterJump,
+        chatSideRouteMode,
+        chatSideNotifier,
+      );
       return;
     }
 
@@ -68,10 +70,15 @@ class ChatTimelineLocation {
       onComplete: () => _blinkNotifier.blinkByMessageId(messageId),
     );
     _messageController.loadAroundMessage(messageId);
-    _closeSideIfNeeded(closeSideAfterJump, chatSideRouteMode);
+    _closeSideIfNeeded(
+      closeSideAfterJump,
+      chatSideRouteMode,
+      chatSideNotifier,
+    );
   }
 
   Future<void> jumpToLatest({
+    required ChatSideNotifier chatSideNotifier,
     bool closeSideAfterJump = false,
     bool chatSideRouteMode = false,
   }) async {
@@ -81,7 +88,11 @@ class ChatTimelineLocation {
           animated: true,
         )) {
       traceChatJump('loaded-window latest handled=true');
-      _closeSideIfNeeded(closeSideAfterJump, chatSideRouteMode);
+      _closeSideIfNeeded(
+        closeSideAfterJump,
+        chatSideRouteMode,
+        chatSideNotifier,
+      );
       return;
     }
 
@@ -90,7 +101,11 @@ class ChatTimelineLocation {
       direction: ChatScrollRestoreDirection.towardNewer,
     );
     _messageController.loadLatestWindow();
-    _closeSideIfNeeded(closeSideAfterJump, chatSideRouteMode);
+    _closeSideIfNeeded(
+      closeSideAfterJump,
+      chatSideRouteMode,
+      chatSideNotifier,
+    );
   }
 
   String? _currentWindowSourceMessageId(MessageState state) {
@@ -106,9 +121,13 @@ class ChatTimelineLocation {
     null => null,
   };
 
-  void _closeSideIfNeeded(bool closeSideAfterJump, bool chatSideRouteMode) {
+  void _closeSideIfNeeded(
+    bool closeSideAfterJump,
+    bool chatSideRouteMode,
+    ChatSideNotifier chatSideNotifier,
+  ) {
     if (!closeSideAfterJump) return;
-    _chatSideNotifier.closeAfterContentJump(routeMode: chatSideRouteMode);
+    chatSideNotifier.closeAfterContentJump(routeMode: chatSideRouteMode);
   }
 }
 
@@ -117,18 +136,26 @@ extension ChatMessageJump on BuildContext {
     String messageId, {
     String? sourceMessageId,
     bool closeSideAfterJump = false,
-  }) => _chatHistoryLocation.jumpToMessage(
-    messageId,
-    sourceMessageId: sourceMessageId,
-    closeSideAfterJump: closeSideAfterJump,
-    chatSideRouteMode: DesktopShellLayout.chatSideRouteModeOf(this),
-  );
+  }) {
+    final routeMode = DesktopShellLayout.chatSideRouteModeOf(this);
+    final chatSideNotifier = read<ChatSideNotifier>();
+    return _chatHistoryLocation.jumpToMessage(
+      messageId,
+      sourceMessageId: sourceMessageId,
+      closeSideAfterJump: closeSideAfterJump,
+      chatSideRouteMode: routeMode,
+      chatSideNotifier: chatSideNotifier,
+    );
+  }
 
-  Future<void> jumpToLatestInChat({bool closeSideAfterJump = false}) =>
-      _chatHistoryLocation.jumpToLatest(
-        closeSideAfterJump: closeSideAfterJump,
-        chatSideRouteMode: DesktopShellLayout.chatSideRouteModeOf(this),
-      );
+  Future<void> jumpToLatestInChat({bool closeSideAfterJump = false}) {
+    final chatSideNotifier = read<ChatSideNotifier>();
+    return _chatHistoryLocation.jumpToLatest(
+      closeSideAfterJump: closeSideAfterJump,
+      chatSideRouteMode: DesktopShellLayout.chatSideRouteModeOf(this),
+      chatSideNotifier: chatSideNotifier,
+    );
+  }
 
   ChatTimelineLocation get _chatHistoryLocation => read<ChatTimelineLocation>();
 }

--- a/test/ui/home/chat/message_jump_test.dart
+++ b/test/ui/home/chat/message_jump_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/ui/home/chat/chat_scroll_coordinator.dart';
+import 'package:flutter_app/ui/home/chat/message_jump.dart';
+import 'package:flutter_app/ui/home/conversation_info_destination.dart';
+import 'package:flutter_app/ui/home/desktop_shell_layout.dart';
+import 'package:flutter_app/ui/home/notifier/blink_notifier.dart';
+import 'package:flutter_app/ui/home/notifier/chat_side_notifier.dart';
+import 'package:flutter_app/ui/home/notifier/message_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+class _BlinkNotifier implements BlinkNotifier {
+  @override
+  void blinkByMessageId(String messageId) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ScrollCoordinator implements ChatScrollCoordinator {
+  @override
+  Future<bool> scrollToMessageIfInLoadedWindow(
+    String messageId, {
+    bool animated = false,
+  }) async => true;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MessageController implements MessageController {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MessageJumpHarness extends StatelessWidget {
+  const _MessageJumpHarness({
+    required this.chatSideNotifier,
+    required this.timeline,
+  });
+
+  final ChatSideNotifier chatSideNotifier;
+  final ChatTimelineLocation timeline;
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+    home: DesktopShellLayout.chatSideRouteMode(
+      routeMode: true,
+      child: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<ChatSideNotifier>.value(
+            value: chatSideNotifier,
+          ),
+          Provider<ChatTimelineLocation>.value(value: timeline),
+        ],
+        child: Builder(
+          builder: (context) => TextButton(
+            onPressed: () {
+              context.jumpToMessageInChat(
+                'target-message',
+                closeSideAfterJump: true,
+              );
+            },
+            child: const Text('jump'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets(
+    'a message jump closes the current narrow search after its notifier changes',
+    (tester) async {
+      final firstNotifier = ChatSideNotifier()
+        ..openDestination(ConversationInfoDestination.searchMessageHistory);
+      final currentNotifier = ChatSideNotifier()
+        ..openDestination(ConversationInfoDestination.searchMessageHistory);
+      addTearDown(firstNotifier.dispose);
+      addTearDown(currentNotifier.dispose);
+
+      final timeline = ChatTimelineLocation(
+        blinkNotifier: _BlinkNotifier(),
+        scrollCoordinator: _ScrollCoordinator(),
+        messageController: _MessageController(),
+      );
+
+      await tester.pumpWidget(
+        _MessageJumpHarness(
+          chatSideNotifier: firstNotifier,
+          timeline: timeline,
+        ),
+      );
+      await tester.pumpWidget(
+        _MessageJumpHarness(
+          chatSideNotifier: currentNotifier,
+          timeline: timeline,
+        ),
+      );
+
+      await tester.tap(find.text('jump'));
+      await tester.pump();
+
+      expect(currentNotifier.state.destinations, isEmpty);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Resolve message jumps against the current chat-side notifier.
- Close narrow chat search after switching conversations.
- Add regression coverage for notifier replacement.

## Testing
- `dart analyze lib/ui/home/chat/chat_page.dart lib/ui/home/chat/message_jump.dart test/ui/home/chat/message_jump_test.dart`
- `flutter test test/ui/home/chat/message_jump_test.dart test/ui/home/notifier/chat_side_notifier_test.dart test/ui/home/desktop_shell_layout_test.dart`