### PR TITLE
fix: search desktop conversations in memory

### DIFF
--- a/lib/core/conversation/conversation_list_store.dart
+++ b/lib/core/conversation/conversation_list_store.dart
@@ -49,6 +49,8 @@ class ConversationListStore {
 
   List<ConversationItem> get items => List.unmodifiable(_sortedItems);
 
+  bool get initialized => _initialized;
+
   ConversationItem? item(String conversationId) => _items[conversationId];
 
   Set<String> conversationIdsInCircle(String circleId) =>

--- a/lib/ui/home/conversation/search_list.dart
+++ b/lib/ui/home/conversation/search_list.dart
@@ -73,55 +73,47 @@ class SearchList extends HookConsumerWidget {
         '';
 
     final accountServer = context.accountServer;
+    final conversationListController = context
+        .read<ConversationListController>();
+    useValueListenable(conversationListController);
 
     final slideCategoryState = ref.watch(slideCategoryStateProvider);
 
     final maoUser = ref.watch(searchMaoUserProvider(keyword)).valueOrNull;
 
     final users =
-        useMemoizedStream(() {
-          if (keyword.trim().isEmpty || filterUnseen) {
-            return Stream.value(<User>[]);
-          }
-          return accountServer.database.userDao
-              .fuzzySearchUser(
-                id: accountServer.userId,
-                username: keyword,
-                identityNumber: keyword,
-                category: slideCategoryState,
-                isIncludeConversation: true,
-              )
-              .watchWithStream(
-                eventStreams: [
-                  DataBaseEventBus.instance.updateConversationIdStream,
-                  DataBaseEventBus.instance.updateUserIdsStream,
-                ],
-                duration: kSlowThrottleDuration,
-              );
-        }, keys: [keyword, filterUnseen, slideCategoryState]).data ??
+        useMemoizedStream(
+          () {
+            if (keyword.trim().isEmpty || filterUnseen) {
+              return Stream.value(<User>[]);
+            }
+            return accountServer.database.userDao
+                .fuzzySearchUser(
+                  id: accountServer.userId,
+                  username: keyword,
+                  identityNumber: keyword,
+                  category: slideCategoryState,
+                  isIncludeConversation: true,
+                )
+                .watchWithStream(
+                  eventStreams: [
+                    DataBaseEventBus.instance.updateConversationIdStream,
+                    DataBaseEventBus.instance.updateUserIdsStream,
+                  ],
+                  duration: kSlowThrottleDuration,
+                );
+          },
+          keys: [keyword, filterUnseen, slideCategoryState],
+          preserveState: false,
+        ).data ??
         [];
 
     final conversations =
-        useMemoizedStream(() {
-          if (keyword.trim().isEmpty) {
-            return Stream.value(<SearchConversationItem>[]);
-          }
-          return accountServer.database.conversationDao
-              .fuzzySearchConversation(
-                keyword,
-                32,
-                filterUnseen: filterUnseen,
-                category: slideCategoryState,
-              )
-              .watchWithStream(
-                eventStreams: [
-                  DataBaseEventBus.instance.updateConversationIdStream,
-                  DataBaseEventBus.instance.updateUserIdsStream,
-                ],
-                duration: kSlowThrottleDuration,
-              );
-        }, keys: [keyword, filterUnseen, slideCategoryState]).data ??
-        [];
+        conversationListController.search(
+          keyword,
+          filterUnseen: filterUnseen,
+        ) ??
+        const <ConversationItem>[];
 
     final messages =
         useMemoizedFuture<List<SearchMessageDetailItem>>(
@@ -135,6 +127,7 @@ class SearchList extends HookConsumerWidget {
                 ),
           [],
           keys: [keyword, filterUnseen, slideCategoryState],
+          preserveState: false,
         ).data ??
         [];
 
@@ -357,7 +350,7 @@ class SearchList extends HookConsumerWidget {
                     ).data;
 
                     return ConversationMenuWrapper(
-                      searchConversation: conversation,
+                      conversation: conversation,
                       child: SearchItemWidget(
                         avatar: ConversationAvatarWidget(
                           conversationId: conversation.conversationId,
@@ -371,7 +364,7 @@ class SearchList extends HookConsumerWidget {
                         name: conversation.validName,
                         description: description,
                         trailing: BadgesWidget(
-                          verified: conversation.isVerified,
+                          verified: conversation.ownerVerified,
                           isBot: conversation.appId != null,
                           membership: conversation.membership,
                         ),

--- a/lib/ui/home/notifier/conversation_list_controller.dart
+++ b/lib/ui/home/notifier/conversation_list_controller.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_app_icon_badge/flutter_app_icon_badge.dart';
 import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart'
-    show ConversationCategory;
+    show ConversationCategory, ConversationStatus;
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import '../../../core/conversation/conversation_list_store.dart';
@@ -80,6 +80,40 @@ class ConversationListController extends ValueNotifier<ConversationListState> {
   ) => _views[slideCategoryState]?.itemScrollController;
 
   void init() => _switchCategory(slideCategoryStateNotifier.state);
+
+  List<ConversationItem>? search(String query, {required bool filterUnseen}) {
+    if (!store.initialized) return null;
+
+    final normalizedQuery = query.toLowerCase();
+    final matches =
+        state.items.where((item) {
+          final name = item.isGroupConversation ? item.groupName : item.name;
+          return (item.isGroupConversation &&
+                      item.status != ConversationStatus.quit ||
+                  item.isStrangerConversation) &&
+              name?.toLowerCase().contains(normalizedQuery) == true &&
+              (!filterUnseen || (item.unseenMessageCount ?? 0) > 0);
+        }).toList()..sort((a, b) {
+          final aName = a.isGroupConversation ? a.groupName : a.name;
+          final bName = b.isGroupConversation ? b.groupName : b.name;
+          final aExact = aName?.toLowerCase() == normalizedQuery;
+          final bExact = bName?.toLowerCase() == normalizedQuery;
+          if (aExact != bExact) return aExact ? -1 : 1;
+          final pin = _compareNullableDateDescending(a.pinTime, b.pinTime);
+          if (pin != 0) return pin;
+          return _compareNullableDateDescending(
+            a.lastMessageCreatedAt,
+            b.lastMessageCreatedAt,
+          );
+        });
+    return matches;
+  }
+
+  static int _compareNullableDateDescending(DateTime? a, DateTime? b) {
+    if (a == null) return b == null ? 0 : 1;
+    if (b == null) return -1;
+    return b.compareTo(a);
+  }
 
   void _switchCategory(SlideCategoryState state) {
     if (state.type == SlideCategoryType.setting) return;

--- a/lib/utils/hook.dart
+++ b/lib/utils/hook.dart
@@ -13,18 +13,25 @@ AsyncSnapshot<T> useMemoizedFuture<T>(
   Future<T> Function() futureBuilder,
   T initialData, {
   List<Object?> keys = const <Object>[],
+  bool preserveState = true,
 }) => _logSnapshotError(
-  useFuture(useMemoized(futureBuilder, keys), initialData: initialData),
+  useFuture(
+    useMemoized(futureBuilder, keys),
+    initialData: initialData,
+    preserveState: preserveState,
+  ),
 );
 
 AsyncSnapshot<T> useMemoizedStream<T>(
   Stream<T> Function() valueBuilder, {
   T? initialData,
   List<Object?> keys = const <Object>[],
+  bool preserveState = true,
 }) => _logSnapshotError(
   useStream<T>(
     useMemoized<Stream<T>>(valueBuilder, keys),
     initialData: initialData,
+    preserveState: preserveState,
   ),
 );
 

--- a/test/ui/home/notifier/conversation_list_controller_test.dart
+++ b/test/ui/home/notifier/conversation_list_controller_test.dart
@@ -58,13 +58,13 @@ void main() {
           const User(
             userId: 'friend',
             identityNumber: '1',
-            fullName: 'Friend',
+            fullName: '主好友',
             relationship: UserRelationship.friend,
           ),
           const User(
             userId: 'stranger',
             identityNumber: '2',
-            fullName: 'Stranger',
+            fullName: '主陌生人',
             relationship: UserRelationship.stranger,
           ),
           const User(
@@ -92,6 +92,7 @@ void main() {
             conversationId: 'group-chat',
             ownerId: 'group-owner',
             category: ConversationCategory.group,
+            name: '主',
             createdAt: now,
             status: ConversationStatus.success,
           ),
@@ -106,9 +107,21 @@ void main() {
         );
     });
 
-    await store.start();
     controller.init();
+    expect(controller.search('主', filterUnseen: false), isNull);
+
+    final initialized = controller.addListenerCompleter();
+    await store.start();
+    await initialized.future;
     expect(controller.state.count, 3);
+    expect(
+      controller
+          .search('主', filterUnseen: false)!
+          .map(
+            (item) => item.conversationId,
+          ),
+      ['group-chat', 'stranger-chat'],
+    );
 
     final contactsChanged = controller.addListenerCompleter();
     categories.select(SlideCategoryType.contacts);
@@ -117,6 +130,7 @@ void main() {
       controller.state.items.map((item) => item.conversationId),
       ['friend-chat'],
     );
+    expect(controller.search('主', filterUnseen: false), isEmpty);
 
     final circleChanged = controller.addListenerCompleter();
     categories.select(SlideCategoryType.circle, 'circle');

--- a/test/utils/hook_test.dart
+++ b/test/utils/hook_test.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_app/utils/hook.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _StreamProbe extends HookWidget {
+  const _StreamProbe({required this.query, required this.stream});
+
+  final String query;
+  final Stream<String> stream;
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot = useMemoizedStream(
+      () => stream,
+      initialData: 'empty',
+      keys: [query],
+      preserveState: false,
+    );
+    return Text(snapshot.data ?? 'loading');
+  }
+}
+
+class _FutureProbe extends HookWidget {
+  const _FutureProbe({required this.query, required this.future});
+
+  final String query;
+  final Future<String> future;
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot = useMemoizedFuture(
+      () => future,
+      'empty',
+      keys: [query],
+      preserveState: false,
+    );
+    return Text(snapshot.data ?? 'loading');
+  }
+}
+
+void main() {
+  testWidgets('clears a stale stream result when its key changes', (
+    tester,
+  ) async {
+    final oldStream = StreamController<String>.broadcast();
+    final currentStream = StreamController<String>.broadcast();
+    addTearDown(oldStream.close);
+    addTearDown(currentStream.close);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _StreamProbe(query: 'old', stream: oldStream.stream),
+      ),
+    );
+    oldStream.add('old result');
+    await tester.pump();
+    expect(find.text('old result'), findsOneWidget);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _StreamProbe(query: 'current', stream: currentStream.stream),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('empty'), findsOneWidget);
+
+    await tester.pump();
+    expect(currentStream.hasListener, isTrue);
+    currentStream.add('current result');
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('current result'), findsOneWidget);
+  });
+
+  testWidgets('clears a stale future result when its key changes', (
+    tester,
+  ) async {
+    final oldFuture = Completer<String>();
+    final currentFuture = Completer<String>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _FutureProbe(query: 'old', future: oldFuture.future),
+      ),
+    );
+    oldFuture.complete('old result');
+    await tester.pump();
+    expect(find.text('old result'), findsOneWidget);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _FutureProbe(query: 'current', future: currentFuture.future),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('empty'), findsOneWidget);
+
+    currentFuture.complete('current result');
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('current result'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Search the Desktop Conversation section from the initialized in-memory conversation list instead of querying SQLite per keyword.
- Keep Conversation and Message results as separate sections. Conversation results include active groups and stranger conversations; friend contacts remain in the Contact section.
- Clear stale Contact and Message results when the query changes.

## Validation
- `dart analyze lib/core/conversation/conversation_list_store.dart lib/ui/home/notifier/conversation_list_controller.dart lib/ui/home/conversation/search_list.dart test/ui/home/notifier/conversation_list_controller_test.dart test/utils/hook_test.dart`
- `flutter test test/ui/home/notifier/conversation_list_controller_test.dart test/utils/hook_test.dart test/ui/home/desktop_shell_layout_test.dart`