### PR TITLE
fix: render long QR payloads

### DIFF
--- a/lib/widgets/qr_code.dart
+++ b/lib/widgets/qr_code.dart
@@ -17,13 +17,30 @@ class QrCode extends StatelessWidget {
     height: dimension,
     color: Colors.white,
     padding: const EdgeInsets.all(8),
-    child: PrettyQrView.data(
-      errorCorrectLevel: QrErrorCorrectLevel.Q,
-      decoration: PrettyQrDecoration(
-        image: image == null ? null : PrettyQrDecorationImage(image: image!),
+    child: _buildQrCode(
+      QrErrorCorrectLevel.Q,
+      errorBuilder: (_, _, _) => _buildQrCode(
+        QrErrorCorrectLevel.L,
+        errorBuilder: (context, _, _) => Center(
+          child: Text(
+            context.l10n.canNotRecognizeQrCode,
+            textAlign: TextAlign.center,
+          ),
+        ),
       ),
-      data: data,
     ),
+  );
+
+  Widget _buildQrCode(
+    int errorCorrectLevel, {
+    ImageErrorWidgetBuilder? errorBuilder,
+  }) => PrettyQrView.data(
+    errorCorrectLevel: errorCorrectLevel,
+    decoration: PrettyQrDecoration(
+      image: image == null ? null : PrettyQrDecorationImage(image: image!),
+    ),
+    errorBuilder: errorBuilder,
+    data: data,
   );
 }
 

--- a/test/widgets/qr_code_test.dart
+++ b/test/widgets/qr_code_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/generated/l10n.dart';
+import 'package:flutter_app/widgets/qr_code.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders a QR code when Q-level capacity is exceeded', (
+    tester,
+  ) async {
+    final data = List.filled(1741, 'a').join();
+
+    await tester.pumpWidget(_app(data));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(Placeholder), findsNothing);
+  });
+
+  testWidgets('shows an error when L-level capacity is exceeded', (
+    tester,
+  ) async {
+    final data = List.filled(3000, 'a').join();
+
+    await tester.pumpWidget(_app(data));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Cannot recognize the QR code'), findsOneWidget);
+  });
+}
+
+Widget _app(String data) => MaterialApp(
+  localizationsDelegates: const [Localization.delegate],
+  supportedLocales: Localization.delegate.supportedLocales,
+  home: Scaffold(body: QrCode(data: data, dimension: 240)),
+);


### PR DESCRIPTION
## Summary
- Retry QR encoding at L error correction when Q capacity is exceeded.
- Show the existing localized error when the payload exceeds L capacity.
- Add coverage for both capacity boundaries.

## Testing
- flutter test test/widgets/qr_code_test.dart test/ui/landing/landing_qrcode_notifier_test.dart
- dart analyze lib/widgets/qr_code.dart test/widgets/qr_code_test.dart