### PR TITLE
fix: improve post message markdown rendering

### DIFF
--- a/lib/widgets/markdown.dart
+++ b/lib/widgets/markdown.dart
@@ -1,321 +1,444 @@
-import 'package:flutter/material.dart';
-import 'package:html/dom.dart' as h;
-import 'package:html/dom_parsing.dart';
-import 'package:html/parser.dart';
-import 'package:markdown/markdown.dart' as m;
-import 'package:markdown_widget/markdown_widget.dart';
-import 'package:mixin_logger/mixin_logger.dart';
+import 'dart:io';
 
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mixin_markdown_widget/mixin_markdown_widget.dart';
+
+import '../ui/provider/setting_provider.dart';
 import '../utils/extension/extension.dart';
 import '../utils/uri_utils.dart';
-import 'high_light_text.dart';
+import 'message/message_style.dart';
 import 'mixin_image.dart';
 
-class MarkdownColumn extends StatelessWidget {
-  const MarkdownColumn({required this.data, super.key});
+const _kMarkdownControllerCacheLimit = 120;
+
+String buildMarkdownCacheKey({
+  required String namespace,
+  required String id,
+}) => '$namespace:$id';
+
+final markdownControllerCache = MarkdownControllerCache();
+
+class MarkdownControllerCache {
+  final _entries = <String, _MarkdownCacheEntry>{};
+
+  MarkdownController acquire(
+    String key,
+    String data, {
+    bool streaming = false,
+  }) {
+    var entry = _entries[key];
+    if (entry == null) {
+      entry = _MarkdownCacheEntry(
+        data: data,
+        controller: MarkdownController(data: data),
+      );
+      _entries[key] = entry;
+    }
+    if (entry.data != data) {
+      _updateEntryData(entry, data, streaming: streaming);
+    } else if (!streaming) {
+      entry.controller.commitStream();
+    }
+    _touch(key, entry);
+    entry.retainCount += 1;
+    _evictIfNeeded();
+    return entry.controller;
+  }
+
+  void release(String key, MarkdownController controller) {
+    final entry = _entries[key];
+    if (entry == null || !identical(entry.controller, controller)) return;
+    if (entry.retainCount > 0) {
+      entry.retainCount -= 1;
+    }
+  }
+
+  void _touch(String key, _MarkdownCacheEntry entry) {
+    _entries.remove(key);
+    _entries[key] = entry;
+  }
+
+  void _evictIfNeeded() {
+    while (_entries.length > _kMarkdownControllerCacheLimit) {
+      String? keyToRemove;
+      _MarkdownCacheEntry? entryToRemove;
+      for (final entry in _entries.entries) {
+        if (entry.value.retainCount == 0) {
+          keyToRemove = entry.key;
+          entryToRemove = entry.value;
+          break;
+        }
+      }
+      if (keyToRemove == null || entryToRemove == null) {
+        return;
+      }
+      _removeEntry(keyToRemove, entryToRemove);
+    }
+  }
+
+  void _removeEntry(String key, _MarkdownCacheEntry entry) {
+    _entries.remove(key);
+    entry.controller.dispose();
+  }
+
+  void _updateEntryData(
+    _MarkdownCacheEntry entry,
+    String data, {
+    required bool streaming,
+  }) {
+    final previousData = entry.data;
+    entry.data = data;
+    if (streaming && data.startsWith(previousData)) {
+      entry.controller.appendChunk(data.substring(previousData.length));
+      return;
+    }
+    entry.controller.setData(data);
+    if (!streaming) {
+      entry.controller.commitStream();
+    }
+  }
+}
+
+class _MarkdownCacheEntry {
+  _MarkdownCacheEntry({
+    required this.data,
+    required this.controller,
+  });
+
+  String data;
+  final MarkdownController controller;
+  int retainCount = 0;
+}
+
+class MarkdownColumn extends HookConsumerWidget {
+  const MarkdownColumn({
+    required this.data,
+    super.key,
+    this.selectable = false,
+    this.cacheKey,
+    this.streaming = false,
+  });
 
   final String data;
+  final bool selectable;
+  final String? cacheKey;
+  final bool streaming;
 
   @override
-  Widget build(BuildContext context) {
-    final widgets =
-        MarkdownGenerator(
-          textGenerator: (node, config, visitor) =>
-              CustomTextNode(node.textContent, config, visitor),
-          generators: _kMixinGenerators,
-          richTextBuilder: CustomText.rich,
-        ).buildWidgets(
-          data,
-          config: _createMarkdownConfig(
-            context: context,
-            darkMode: context.brightness == Brightness.dark,
-          ),
-        );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final chatFontSizeDelta = ref.watch(
+      settingProvider.select((value) => value.chatFontSizeDelta),
+    );
+
     return ClipRect(
-      child: DefaultTextStyle.merge(
-        style: TextStyle(color: context.theme.text),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: widgets,
-        ),
+      child: _MarkdownView(
+        data: data,
+        cacheKey: cacheKey,
+        streaming: streaming,
+        useColumn: true,
+        selectable: selectable,
+        contextMenuBuilder: (_, _, _, _) => const SizedBox.shrink(),
+        padding: EdgeInsets.zero,
+        theme: _createMarkdownTheme(context, chatFontSizeDelta),
+        imageBuilder: _buildMarkdownImage,
+        onTapLink: (destination, title, label) {
+          if (destination.isEmpty) return;
+          openUri(context, destination);
+        },
       ),
     );
   }
 }
 
-class Markdown extends StatelessWidget {
+class Markdown extends HookConsumerWidget {
   const Markdown({
     required this.data,
     super.key,
     this.padding = EdgeInsets.zero,
     this.physics,
+    this.cacheKey,
+    this.streaming = false,
+    this.maxContentWidth,
   });
 
   final String data;
   final EdgeInsetsGeometry? padding;
   final ScrollPhysics? physics;
+  final String? cacheKey;
+  final bool streaming;
+  final double? maxContentWidth;
 
   @override
-  Widget build(BuildContext context) => DefaultTextStyle.merge(
-    style: TextStyle(color: context.theme.text),
-    child: MarkdownWidget(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final chatFontSizeDelta = ref.watch(
+      settingProvider.select((value) => value.chatFontSizeDelta),
+    );
+
+    return _MarkdownView(
       data: data,
+      cacheKey: cacheKey,
+      streaming: streaming,
       padding: padding,
       physics: physics,
-      config: _createMarkdownConfig(
-        context: context,
-        darkMode: context.brightness == Brightness.dark,
+      theme: _createMarkdownTheme(
+        context,
+        chatFontSizeDelta,
+        maxContentWidth: maxContentWidth,
       ),
-      markdownGenerator: MarkdownGenerator(
-        textGenerator: (node, config, visitor) =>
-            CustomTextNode(node.textContent, config, visitor),
-        generators: _kMixinGenerators,
-        richTextBuilder: CustomText.rich,
-      ),
-    ),
-  );
-}
-
-MarkdownConfig _createMarkdownConfig({
-  required BuildContext context,
-  required bool darkMode,
-}) => MarkdownConfig(
-  configs: [
-    if (darkMode) ...[
-      HrConfig.darkConfig,
-      H2Config.darkConfig,
-      H3Config.darkConfig,
-      H4Config.darkConfig,
-      H5Config.darkConfig,
-      H6Config.darkConfig,
-      PreConfig.darkConfig,
-      PConfig.darkConfig,
-      CodeConfig.darkConfig,
-    ],
-    _MixinH1Config(darkMode),
-    ImgConfig(
-      builder: (url, attributes) {
-        double? width;
-        double? height;
-        if (attributes['width'] != null) {
-          width = double.parse(attributes['width']!);
-        }
-        if (attributes['height'] != null) {
-          height = double.parse(attributes['height']!);
-        }
-        final imageUrl = url;
-        return ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 400),
-          child: MixinImage.network(imageUrl, width: width, height: height),
-        );
+      imageBuilder: _buildMarkdownImage,
+      onTapLink: (destination, title, label) {
+        if (destination.isEmpty) return;
+        openUri(context, destination);
       },
-    ),
-    LinkConfig(
-      style: TextStyle(color: context.theme.accent),
-      onTap: (href) {
-        if (href.isEmpty) return;
-        openUri(context, href);
-      },
-    ),
-    ListConfig(
-      marker: (isOrdered, depth, index) {
-        final style = DefaultTextStyle.of(context).style;
-        final height = (style.fontSize ?? 16) * (style.height ?? 1.25);
-        return getDefaultMarker(
-          isOrdered,
-          depth,
-          context.theme.text,
-          index,
-          height / 2 + 1,
-          MarkdownConfig(),
-        );
-      },
-    ),
-  ],
-);
-
-class _MixinH1Config extends HeadingConfig {
-  _MixinH1Config(this.dark);
-
-  final bool dark;
-
-  @override
-  HeadingDivider? get divider => null;
-
-  @override
-  TextStyle get style => TextStyle(
-    fontSize: 32,
-    height: 40 / 32,
-    color: dark ? Colors.white : null,
-    fontWeight: FontWeight.bold,
-  );
-
-  @override
-  String get tag => MarkdownTag.h1.name;
-}
-
-final RegExp htmlRep = RegExp('<[^>]*>', multiLine: true);
-
-/// parse [m.Node] to [h.Node]
-/// https://github.com/asjqkkkk/markdown_widget/blob/1d549fd5c2d6b0172281d8bb66e367654b9d60f0/example/lib/markdown_custom/html_support.dart
-List<SpanNode> _parseHtml(
-  m.Text node, {
-  ValueCallback<dynamic>? onError,
-  WidgetVisitor? visitor,
-  TextStyle? parentStyle,
-}) {
-  try {
-    final text = node.textContent.replaceAll(
-      RegExp(r'(\r?\n)|(\r?\t)|(\r)'),
-      '',
     );
-    if (!text.contains(htmlRep)) return [TextNode(text: node.text)];
-    final document = parseFragment(text);
-    return HtmlToSpanVisitor(
-      visitor: visitor,
-      parentStyle: parentStyle,
-    ).toVisit(document.nodes.toList());
-  } catch (e) {
-    onError?.call(e);
-    return [TextNode(text: node.text)];
   }
 }
 
-class HtmlElement extends m.Element {
-  HtmlElement(super.tag, super.children, this.textContent);
+class _MarkdownView extends HookWidget {
+  const _MarkdownView({
+    required this.data,
+    required this.theme,
+    required this.imageBuilder,
+    required this.onTapLink,
+    this.cacheKey,
+    this.padding,
+    this.physics,
+    this.streaming = false,
+    this.useColumn = false,
+    this.selectable = true,
+    this.contextMenuBuilder,
+  });
+
+  final String data;
+  final String? cacheKey;
+  final bool streaming;
+  final MarkdownThemeData theme;
+  final EdgeInsetsGeometry? padding;
+  final ScrollPhysics? physics;
+  final bool useColumn;
+  final bool selectable;
+  final MarkdownImageBuilder imageBuilder;
+  final MarkdownTapLinkCallback onTapLink;
+  final MarkdownContextMenuBuilder? contextMenuBuilder;
 
   @override
-  final String textContent;
-}
-
-class HtmlToSpanVisitor extends TreeVisitor {
-  HtmlToSpanVisitor({WidgetVisitor? visitor, TextStyle? parentStyle})
-    : visitor = visitor ?? WidgetVisitor(),
-      parentStyle = parentStyle ?? const TextStyle();
-  final List<SpanNode> _spans = [];
-  final List<SpanNode> _spansStack = [];
-  final WidgetVisitor visitor;
-  final TextStyle parentStyle;
-
-  List<SpanNode> toVisit(List<h.Node> nodes) {
-    _spans.clear();
-    for (final node in nodes) {
-      final emptyNode = ConcreteElementNode(style: parentStyle);
-      _spans.add(emptyNode);
-      _spansStack.add(emptyNode);
-      visit(node);
-      _spansStack.removeLast();
+  Widget build(BuildContext context) {
+    if (cacheKey == null) {
+      return _buildMarkdownWidget(data: data);
     }
-    final result = List.of(_spans);
-    _spans.clear();
-    _spansStack.clear();
-    return result;
-  }
 
-  @override
-  void visitText(h.Text node) {
-    final last = _spansStack.last;
-    if (last is ElementNode) {
-      final textNode = TextNode(text: node.text);
-      last.accept(textNode);
-    }
-  }
-
-  @override
-  void visitElement(h.Element node) {
-    final localName = node.localName ?? '';
-    final mdElement = m.Element(localName, []);
-    mdElement.attributes.addAll(node.attributes.cast());
-    var spanNode = visitor.getNodeByElement(mdElement, visitor.config);
-    if (spanNode is! ElementNode) {
-      final n = ConcreteElementNode(tag: localName)..accept(spanNode);
-      spanNode = n;
-    }
-    final last = _spansStack.last;
-    if (last is ElementNode) {
-      last.accept(spanNode);
-    }
-    _spansStack.add(spanNode);
-    node.nodes.toList(growable: false).forEach(visit);
-    _spansStack.removeLast();
-  }
-}
-
-class CustomTextNode extends ElementNode {
-  CustomTextNode(this.text, this.config, this.visitor);
-
-  final String text;
-  final MarkdownConfig config;
-  final WidgetVisitor visitor;
-
-  @override
-  void onAccepted(SpanNode parent) {
-    final textStyle = config.p.textStyle.merge(parentStyle);
-    children.clear();
-    if (!text.contains(htmlRep)) {
-      accept(TextNode(text: text, style: textStyle));
-      return;
-    }
-    _parseHtml(
-      m.Text(text),
-      visitor: WidgetVisitor(
-        config: visitor.config,
-        generators: visitor.generators,
+    final key = cacheKey!;
+    final controller = useMemoized(
+      () => markdownControllerCache.acquire(
+        key,
+        data,
+        streaming: streaming,
       ),
-      parentStyle: parentStyle,
-    ).forEach(accept);
+      [key, data, streaming],
+    );
+
+    useEffect(
+      () => () {
+        markdownControllerCache.release(key, controller);
+      },
+      [key, data, streaming, controller],
+    );
+
+    return _buildMarkdownWidget(controller: controller);
   }
+
+  Widget _buildMarkdownWidget({
+    String? data,
+    MarkdownController? controller,
+  }) => MarkdownWidget(
+    data: data,
+    controller: controller,
+    padding: padding,
+    physics: physics,
+    useColumn: useColumn,
+    selectable: selectable,
+    contextMenuBuilder: contextMenuBuilder,
+    theme: theme,
+    imageBuilder: imageBuilder,
+    onTapLink: onTapLink,
+  );
 }
 
-final _kMixinGenerators = <SpanNodeGeneratorWithTag>[
-  SpanNodeGeneratorWithTag(
-    tag: MarkdownTag.pre.name,
-    generator: (e, config, visitor) =>
-        _MixinCodeBlockNode(e, config.pre, visitor),
-  ),
-];
+Widget _buildMarkdownImage(
+  BuildContext context,
+  ImageBlock block,
+  MarkdownThemeData theme,
+) {
+  final uri = Uri.tryParse(block.url);
+  final width = _tryParseImageDimension(uri, 'w', 'width');
+  final height = _tryParseImageDimension(uri, 'h', 'height');
 
-class _MixinCodeBlockNode extends CodeBlockNode {
-  _MixinCodeBlockNode(super.content, super.preConfig, super.visitor);
-
-  @override
-  InlineSpan build() {
-    var language = preConfig.language;
-    try {
-      final languageValue =
-          (element.children!.first as m.Element).attributes['class']!;
-      language = languageValue.split('-').last;
-    } catch (e) {
-      i('get language error:$e');
+  Widget errorBuilder(BuildContext context, Object error, StackTrace? stack) {
+    final iconColor = theme.bodyStyle.color?.withValues(alpha: 0.72);
+    if (width != null && height != null) {
+      return Container(
+        width: width,
+        height: height,
+        color: theme.imagePlaceholderBackgroundColor,
+        alignment: Alignment.center,
+        child: Icon(Icons.broken_image_outlined, color: theme.dividerColor),
+      );
     }
-    final splitContents = content.trim().split(RegExp(r'(\r?\n)|(\r?\t)|(\r)'));
-    if (splitContents.last.isEmpty) splitContents.removeLast();
-    final widget = Container(
-      decoration: preConfig.decoration,
-      margin: preConfig.margin,
-      padding: preConfig.padding,
-      width: double.infinity,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: List.generate(splitContents.length, (index) {
-          final currentContent = splitContents[index];
-          return ProxyRichText(
-            TextSpan(
-              children: highLightSpans(
-                currentContent,
-                language: preConfig.language,
-                theme: preConfig.theme,
-                textStyle: style,
-                styleNotMatched: preConfig.styleNotMatched,
-              ),
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: theme.imagePlaceholderBackgroundColor,
+        borderRadius: theme.imageBorderRadius,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.broken_image_outlined, size: 18, color: iconColor),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              block.alt?.isNotEmpty == true ? block.alt! : 'Image',
+              style: theme.bodyStyle.copyWith(color: iconColor),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
-            richTextBuilder: visitor.richTextBuilder,
-          );
-        }),
+          ),
+        ],
       ),
     );
-    return WidgetSpan(
-      child: preConfig.wrapper?.call(widget, content, language) ?? widget,
+  }
+
+  final image = _buildMixinImageForUrl(
+    block.url,
+    width: width,
+    height: height,
+    errorBuilder: errorBuilder,
+  );
+
+  return ClipRRect(
+    borderRadius: theme.imageBorderRadius,
+    child: image,
+  );
+}
+
+double? _tryParseImageDimension(Uri? uri, String shortKey, String fullKey) {
+  if (uri == null) return null;
+  final value = uri.queryParameters[shortKey] ?? uri.queryParameters[fullKey];
+  return value == null ? null : double.tryParse(value);
+}
+
+Widget _buildMixinImageForUrl(
+  String url, {
+  double? width,
+  double? height,
+  ImageErrorWidgetBuilder? errorBuilder,
+}) {
+  final uri = Uri.tryParse(url);
+  if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+    return MixinImage.network(
+      url,
+      width: width,
+      height: height,
+      errorBuilder: errorBuilder,
     );
   }
+
+  if (uri != null && uri.scheme == 'file') {
+    return MixinImage.file(
+      File.fromUri(uri),
+      width: width,
+      height: height,
+      errorBuilder: errorBuilder,
+    );
+  }
+
+  final file = File(url);
+  if (file.isAbsolute) {
+    return MixinImage.file(
+      file,
+      width: width,
+      height: height,
+      errorBuilder: errorBuilder,
+    );
+  }
+
+  return MixinImage.asset(
+    url,
+    width: width,
+    height: height,
+    errorBuilder: errorBuilder,
+  );
+}
+
+MarkdownThemeData _createMarkdownTheme(
+  BuildContext context,
+  double chatFontSizeDelta, {
+  double? maxContentWidth,
+}) {
+  final foreground = context.brightness == Brightness.dark
+      ? MarkdownThemeForeground.dark
+      : MarkdownThemeForeground.light;
+  final base = MarkdownThemeData.themed(
+    context,
+    foreground: foreground,
+  );
+  final textColor = context.theme.text;
+  final accentColor = context.theme.accent;
+  final chatBodyFontSize =
+      MessageStyle.defaultStyle.primaryFontSize + chatFontSizeDelta;
+  final baseBodyFontSize = base.bodyStyle.fontSize ?? chatBodyFontSize;
+  final fontSizeScale = baseBodyFontSize == 0
+      ? 1.0
+      : chatBodyFontSize / baseBodyFontSize;
+
+  TextStyle applyTextColor(TextStyle style) => style.copyWith(color: textColor);
+  TextStyle scaleFontSize(TextStyle style) {
+    final fontSize = style.fontSize;
+    if (fontSize == null) return style;
+    return style.copyWith(fontSize: fontSize * fontSizeScale);
+  }
+
+  TextStyle applyTextStyle(TextStyle style) =>
+      applyTextColor(scaleFontSize(style));
+
+  return base.copyWith(
+    bodyStyle: applyTextStyle(base.bodyStyle),
+    quoteStyle: scaleFontSize(
+      base.quoteStyle.copyWith(
+        color: base.quoteStyle.color ?? textColor.withValues(alpha: 0.82),
+      ),
+    ),
+    linkStyle: base.linkStyle.copyWith(
+      color: accentColor,
+      decorationColor: accentColor,
+      fontSize:
+          (base.linkStyle.fontSize ??
+              base.bodyStyle.fontSize ??
+              chatBodyFontSize) *
+          fontSizeScale,
+      decoration: .none,
+    ),
+    inlineCodeStyle: applyTextStyle(base.inlineCodeStyle),
+    codeBlockStyle: applyTextStyle(base.codeBlockStyle),
+    tableHeaderStyle: applyTextStyle(base.tableHeaderStyle),
+    heading1Style: applyTextStyle(
+      base.heading1Style.copyWith(
+        height: 40 / 32,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+    heading2Style: applyTextStyle(base.heading2Style),
+    heading3Style: applyTextStyle(base.heading3Style),
+    heading4Style: applyTextStyle(base.heading4Style),
+    heading5Style: applyTextStyle(base.heading5Style),
+    heading6Style: applyTextStyle(base.heading6Style),
+    quoteBorderColor: accentColor.withValues(alpha: 0.4),
+    selectionColor: accentColor.withValues(alpha: 0.24),
+    maxContentWidth: maxContentWidth,
+    showHeading1Divider: false,
+    quoteBackgroundColor: Colors.transparent,
+  );
 }

--- a/lib/widgets/message/item/post_message.dart
+++ b/lib/widgets/message/item/post_message.dart
@@ -34,7 +34,14 @@ class PostMessage extends HookConsumerWidget {
         constraints: const BoxConstraints(maxWidth: 400),
         child: DefaultTextStyle.merge(
           style: TextStyle(fontSize: context.messageStyle.primaryFontSize),
-          child: MessagePost(showStatus: true, content: content),
+          child: MessagePost(
+            showStatus: true,
+            content: content,
+            cacheKey: buildMarkdownCacheKey(
+              namespace: 'post',
+              id: context.message.messageId,
+            ),
+          ),
         ),
       ),
     );
@@ -49,6 +56,7 @@ class MessagePost extends StatelessWidget {
     this.padding,
     this.decoration,
     this.clickable = true,
+    this.cacheKey,
   });
 
   final EdgeInsetsGeometry? padding;
@@ -56,6 +64,7 @@ class MessagePost extends StatelessWidget {
   final bool showStatus;
   final String content;
   final bool clickable;
+  final String? cacheKey;
 
   @override
   Widget build(BuildContext context) => InteractiveDecoratedBox(
@@ -84,7 +93,10 @@ class MessagePost extends StatelessWidget {
                   ).copyWith(scrollbars: false),
                   child: SingleChildScrollView(
                     physics: const NeverScrollableScrollPhysics(),
-                    child: MarkdownColumn(data: postContent),
+                    child: MarkdownColumn(
+                      data: postContent,
+                      cacheKey: cacheKey,
+                    ),
                   ),
                 ),
               );
@@ -158,12 +170,14 @@ class PostPreview extends StatelessWidget {
           actions: [MixinCloseButton(onTap: () => Navigator.pop(context))],
         ),
         Expanded(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 600),
-            child: Markdown(
-              data: message.content ?? '',
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 32),
+          child: Markdown(
+            data: message.content ?? '',
+            cacheKey: buildMarkdownCacheKey(
+              namespace: 'post-preview',
+              id: message.messageId,
             ),
+            maxContentWidth: double.infinity,
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 32),
           ),
         ),
       ],

--- a/lib/widgets/message/item/post_message.dart
+++ b/lib/widgets/message/item/post_message.dart
@@ -170,23 +170,14 @@ class PostPreview extends StatelessWidget {
           actions: [MixinCloseButton(onTap: () => Navigator.pop(context))],
         ),
         Expanded(
-          child: Align(
-            alignment: Alignment.topCenter,
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 1264),
-              child: Markdown(
-                data: message.content ?? '',
-                cacheKey: buildMarkdownCacheKey(
-                  namespace: 'post-preview',
-                  id: message.messageId,
-                ),
-                maxContentWidth: 1200,
-                padding: const EdgeInsets.symmetric(
-                  vertical: 8,
-                  horizontal: 32,
-                ),
-              ),
+          child: Markdown(
+            data: message.content ?? '',
+            cacheKey: buildMarkdownCacheKey(
+              namespace: 'post-preview',
+              id: message.messageId,
             ),
+            maxContentWidth: double.infinity,
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 32),
           ),
         ),
       ],

--- a/lib/widgets/message/item/post_message.dart
+++ b/lib/widgets/message/item/post_message.dart
@@ -176,7 +176,7 @@ class PostPreview extends StatelessWidget {
               namespace: 'post-preview',
               id: message.messageId,
             ),
-            maxContentWidth: double.infinity,
+            maxContentWidth: 1200,
             padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 32),
           ),
         ),

--- a/lib/widgets/message/item/post_message.dart
+++ b/lib/widgets/message/item/post_message.dart
@@ -170,14 +170,23 @@ class PostPreview extends StatelessWidget {
           actions: [MixinCloseButton(onTap: () => Navigator.pop(context))],
         ),
         Expanded(
-          child: Markdown(
-            data: message.content ?? '',
-            cacheKey: buildMarkdownCacheKey(
-              namespace: 'post-preview',
-              id: message.messageId,
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 1264),
+              child: Markdown(
+                data: message.content ?? '',
+                cacheKey: buildMarkdownCacheKey(
+                  namespace: 'post-preview',
+                  id: message.messageId,
+                ),
+                maxContentWidth: 1200,
+                padding: const EdgeInsets.symmetric(
+                  vertical: 8,
+                  horizontal: 32,
+                ),
+              ),
             ),
-            maxContentWidth: 1200,
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 32),
           ),
         ),
       ],

--- a/lib/widgets/message/send_message_dialog/send_message_dialog.dart
+++ b/lib/widgets/message/send_message_dialog/send_message_dialog.dart
@@ -508,7 +508,11 @@ class _Post extends StatelessWidget {
     child: Padding(
       padding: const EdgeInsets.all(36),
       child: _MessageBubble(
-        child: MessagePost(showStatus: false, content: content),
+        child: MessagePost(
+          showStatus: false,
+          content: content,
+          clickable: false,
+        ),
       ),
     ),
   );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -619,14 +619,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  flutter_highlight:
-    dependency: transitive
-    description:
-      name: flutter_highlight
-      sha256: "7b96333867aa07e122e245c033b8ad622e4e3a42a1a2372cbb098a2541d8782c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.0"
   flutter_hooks:
     dependency: "direct main"
     description:
@@ -688,6 +680,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_math_fork:
+    dependency: transitive
+    description:
+      name: flutter_math_fork
+      sha256: "6d5f2f1aa57ae539ffb0a04bb39d2da67af74601d685a161aff7ce5bda5fa407"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.4"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -795,14 +795,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
-  highlight:
-    dependency: transitive
-    description:
-      name: highlight
-      sha256: "5353a83ffe3e3eca7df0abfb72dcf3fa66cc56b953728e7113ad4ad88497cf21"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.0"
   hive:
     dependency: "direct main"
     description:
@@ -1171,14 +1163,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.3.1"
-  markdown_widget:
-    dependency: "direct main"
-    description:
-      name: markdown_widget
-      sha256: b52c13d3ee4d0e60c812e15b0593f142a3b8a2003cde1babb271d001a1dbdc1c
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.2+8"
   matcher:
     dependency: transitive
     description:
@@ -1227,6 +1211,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  mixin_markdown_widget:
+    dependency: "direct main"
+    description:
+      name: mixin_markdown_widget
+      sha256: "4b4f6430c3be9be5766ae06b0d6c78ab6bd3059c1f2df076ef325028b6f030d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   msix:
     dependency: "direct dev"
     description:
@@ -1524,6 +1516,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.2"
+  pretext:
+    dependency: transitive
+    description:
+      name: pretext
+      sha256: "414ef08acce07d877ec62348a56c998d8d45eab4cc6bfab35a7287520c6e4c7c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   pretty_qr_code:
     dependency: "direct main"
     description:
@@ -1628,6 +1628,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
+  re_highlight:
+    dependency: transitive
+    description:
+      name: re_highlight
+      sha256: "6c4ac3f76f939fb7ca9df013df98526634e17d8f7460e028bd23a035870024f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
   recase:
     dependency: "direct main"
     description:
@@ -1708,14 +1716,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
-  scroll_to_index:
-    dependency: transitive
-    description:
-      name: scroll_to_index
-      sha256: b707546e7500d9f070d63e5acf74fd437ec7eeeb68d3412ef7b0afada0b4f176
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.1"
   scrollable_positioned_list:
     dependency: "direct main"
     description:
@@ -1945,6 +1945,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,7 +89,7 @@ dependencies:
   local_auth: ^3.0.1
   lottie: ^3.3.3
   map: ^2.0.2
-  markdown_widget: ^2.3.2+2
+  mixin_markdown_widget: ^0.3.1
   mime: ^2.0.0
   mixin_bot_sdk_dart: ^1.5.0
   mixin_logger: ^0.2.0

--- a/test/widgets/markdown_test.dart
+++ b/test/widgets/markdown_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/constants/brightness_theme_data.dart';
+import 'package:flutter_app/ui/provider/setting_provider.dart';
+import 'package:flutter_app/widgets/brightness_observer.dart';
+import 'package:flutter_app/widgets/markdown.dart';
+import 'package:flutter_app/widgets/message/item/post_message.dart';
+import 'package:flutter_app/widgets/message/message_style.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mixin_markdown_widget/mixin_markdown_widget.dart'
+    as mixin_markdown;
+
+void main() {
+  testWidgets('renders PostMessage Markdown with mixin_markdown_widget', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app(const MarkdownColumn(data: '# Post title')));
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(mixin_markdown.MarkdownWidget), findsOneWidget);
+    expect(find.text('Post title'), findsOneWidget);
+  });
+
+  testWidgets('allows unrestricted Markdown preview width', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        const Markdown(
+          data: '# Post title',
+          maxContentWidth: double.infinity,
+        ),
+      ),
+    );
+
+    final markdown = tester.widget<mixin_markdown.MarkdownWidget>(
+      find.byType(mixin_markdown.MarkdownWidget),
+    );
+
+    expect(markdown.theme!.maxContentWidth, double.infinity);
+  });
+
+  testWidgets('scales PostMessage H1 once with the chat font setting', (
+    tester,
+  ) async {
+    const chatFontSizeDelta = 4.0;
+    await tester.pumpWidget(
+      _app(
+        const MarkdownColumn(data: '# Post title'),
+        chatFontSizeDelta: chatFontSizeDelta,
+      ),
+    );
+
+    final markdown = tester.widget<mixin_markdown.MarkdownWidget>(
+      find.byType(mixin_markdown.MarkdownWidget),
+    );
+    final context = tester.element(find.byType(mixin_markdown.MarkdownWidget));
+    final base = mixin_markdown.MarkdownThemeData.themed(context);
+    final scale =
+        (MessageStyle.defaultStyle.primaryFontSize + chatFontSizeDelta) /
+        (base.bodyStyle.fontSize ?? MessageStyle.defaultStyle.primaryFontSize);
+
+    expect(
+      markdown.theme!.heading1Style.fontSize,
+      closeTo((base.heading1Style.fontSize ?? 0) * scale, 0.001),
+    );
+  });
+
+  testWidgets('renders a post draft without MessageContext', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        const MessagePost(
+          showStatus: false,
+          clickable: false,
+          content: '# Draft post',
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Draft post'), findsOneWidget);
+  });
+
+  test('updates a cached controller when post content changes', () {
+    final cache = MarkdownControllerCache();
+    final initial = cache.acquire('post:message', 'old content');
+    final updated = cache.acquire('post:message', 'new content');
+
+    expect(updated, same(initial));
+    expect(updated.data, 'new content');
+    expect(updated.plainText, 'new content');
+
+    cache
+      ..release('post:message', initial)
+      ..release('post:message', updated);
+  });
+
+  testWidgets('releases a cached controller after PostMessage updates', (
+    tester,
+  ) async {
+    const key = 'post:widget-cache';
+    final initial = markdownControllerCache.acquire(key, 'version 0');
+    markdownControllerCache.release(key, initial);
+
+    for (var version = 1; version <= 120; version += 1) {
+      await tester.pumpWidget(
+        _app(MarkdownColumn(data: 'version $version', cacheKey: key)),
+      );
+    }
+    await tester.pumpWidget(_app(const SizedBox()));
+
+    for (var index = 0; index < 120; index += 1) {
+      final other = markdownControllerCache.acquire(
+        'post:widget-cache-$index',
+        'other $index',
+      );
+      markdownControllerCache.release('post:widget-cache-$index', other);
+    }
+
+    final replacement = markdownControllerCache.acquire(key, 'version 120');
+
+    expect(replacement, isNot(same(initial)));
+
+    markdownControllerCache.release(key, replacement);
+  });
+}
+
+Widget _app(
+  Widget child, {
+  double chatFontSizeDelta = 0,
+}) => ProviderScope(
+  overrides: [
+    settingProvider.overrideWith(
+      (ref) => SettingChangeNotifier(chatFontSizeDelta: chatFontSizeDelta),
+    ),
+  ],
+  child: MaterialApp(
+    home: BrightnessData(
+      value: 0,
+      brightnessThemeData: lightBrightnessThemeData,
+      child: Scaffold(body: child),
+    ),
+  ),
+);

--- a/test/widgets/markdown_test.dart
+++ b/test/widgets/markdown_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/constants/brightness_theme_data.dart';
+import 'package:flutter_app/db/mixin_database.dart';
 import 'package:flutter_app/ui/provider/setting_provider.dart';
 import 'package:flutter_app/widgets/brightness_observer.dart';
 import 'package:flutter_app/widgets/markdown.dart';
@@ -7,6 +8,7 @@ import 'package:flutter_app/widgets/message/item/post_message.dart';
 import 'package:flutter_app/widgets/message/message_style.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
 import 'package:mixin_markdown_widget/mixin_markdown_widget.dart'
     as mixin_markdown;
 
@@ -36,6 +38,27 @@ void main() {
     );
 
     expect(markdown.theme!.maxContentWidth, 1200);
+  });
+
+  testWidgets('centers the 1200px PostPreview content', (tester) async {
+    await tester.pumpWidget(_app(PostPreview(message: _postMessage())));
+
+    final content = find.byWidgetPredicate(
+      (widget) =>
+          widget is ConstrainedBox && widget.constraints.maxWidth == 1264,
+    );
+
+    expect(content, findsOneWidget);
+    expect(
+      find.ancestor(
+        of: content,
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is Align && widget.alignment == Alignment.topCenter,
+        ),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('scales PostMessage H1 once with the chat font setting', (
@@ -122,6 +145,21 @@ void main() {
     markdownControllerCache.release(key, replacement);
   });
 }
+
+MessageItem _postMessage() => MessageItem(
+  messageId: 'post-message',
+  conversationId: 'conversation',
+  content: '# Post title',
+  type: 'POST',
+  createdAt: DateTime(2026),
+  status: MessageStatus.delivered,
+  userId: 'user',
+  userFullName: 'User',
+  userIdentityNumber: '0',
+  isVerified: false,
+  sharedUserIsVerified: false,
+  pinned: false,
+);
 
 Widget _app(
   Widget child, {

--- a/test/widgets/markdown_test.dart
+++ b/test/widgets/markdown_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/constants/brightness_theme_data.dart';
-import 'package:flutter_app/db/mixin_database.dart';
 import 'package:flutter_app/ui/provider/setting_provider.dart';
 import 'package:flutter_app/widgets/brightness_observer.dart';
 import 'package:flutter_app/widgets/markdown.dart';
@@ -8,7 +7,6 @@ import 'package:flutter_app/widgets/message/item/post_message.dart';
 import 'package:flutter_app/widgets/message/message_style.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
 import 'package:mixin_markdown_widget/mixin_markdown_widget.dart'
     as mixin_markdown;
 
@@ -23,12 +21,12 @@ void main() {
     expect(find.text('Post title'), findsOneWidget);
   });
 
-  testWidgets('allows a 1200px Markdown preview width', (tester) async {
+  testWidgets('allows unrestricted Markdown preview width', (tester) async {
     await tester.pumpWidget(
       _app(
         const Markdown(
           data: '# Post title',
-          maxContentWidth: 1200,
+          maxContentWidth: double.infinity,
         ),
       ),
     );
@@ -37,28 +35,7 @@ void main() {
       find.byType(mixin_markdown.MarkdownWidget),
     );
 
-    expect(markdown.theme!.maxContentWidth, 1200);
-  });
-
-  testWidgets('centers the 1200px PostPreview content', (tester) async {
-    await tester.pumpWidget(_app(PostPreview(message: _postMessage())));
-
-    final content = find.byWidgetPredicate(
-      (widget) =>
-          widget is ConstrainedBox && widget.constraints.maxWidth == 1264,
-    );
-
-    expect(content, findsOneWidget);
-    expect(
-      find.ancestor(
-        of: content,
-        matching: find.byWidgetPredicate(
-          (widget) =>
-              widget is Align && widget.alignment == Alignment.topCenter,
-        ),
-      ),
-      findsOneWidget,
-    );
+    expect(markdown.theme!.maxContentWidth, double.infinity);
   });
 
   testWidgets('scales PostMessage H1 once with the chat font setting', (
@@ -145,21 +122,6 @@ void main() {
     markdownControllerCache.release(key, replacement);
   });
 }
-
-MessageItem _postMessage() => MessageItem(
-  messageId: 'post-message',
-  conversationId: 'conversation',
-  content: '# Post title',
-  type: 'POST',
-  createdAt: DateTime(2026),
-  status: MessageStatus.delivered,
-  userId: 'user',
-  userFullName: 'User',
-  userIdentityNumber: '0',
-  isVerified: false,
-  sharedUserIsVerified: false,
-  pinned: false,
-);
 
 Widget _app(
   Widget child, {

--- a/test/widgets/markdown_test.dart
+++ b/test/widgets/markdown_test.dart
@@ -21,12 +21,12 @@ void main() {
     expect(find.text('Post title'), findsOneWidget);
   });
 
-  testWidgets('allows unrestricted Markdown preview width', (tester) async {
+  testWidgets('allows a 1200px Markdown preview width', (tester) async {
     await tester.pumpWidget(
       _app(
         const Markdown(
           data: '# Post title',
-          maxContentWidth: double.infinity,
+          maxContentWidth: 1200,
         ),
       ),
     );
@@ -35,7 +35,7 @@ void main() {
       find.byType(mixin_markdown.MarkdownWidget),
     );
 
-    expect(markdown.theme!.maxContentWidth, double.infinity);
+    expect(markdown.theme!.maxContentWidth, 1200);
   });
 
   testWidgets('scales PostMessage H1 once with the chat font setting', (


### PR DESCRIPTION
## Summary
- Render post messages with `mixin_markdown_widget`.
- Reuse Markdown controllers for post cards and previews without retaining stale content.
- Let the full post preview use up to 1200px with horizontal padding.

## Testing
- `flutter test test/widgets/markdown_test.dart`
- `dart analyze lib/widgets/markdown.dart lib/widgets/message/item/post_message.dart lib/widgets/message/send_message_dialog/send_message_dialog.dart test/widgets/markdown_test.dart`