### PR TITLE
fix: polish settings UI

### DIFF
--- a/lib/ui/home/home.dart
+++ b/lib/ui/home/home.dart
@@ -327,12 +327,13 @@ class _CenterPage extends HookConsumerWidget {
         majorNavigationProvider.notifier,
       );
 
-      if (majorNavigationNotifier.syncSettingCategory(
-        isSetting,
-        routeMode: routeMode,
-      )) {
+      if (isSetting && !routeMode) {
         ref.read(conversationProvider.notifier).unselected();
       }
+      majorNavigationNotifier.syncSettingCategory(
+        isSetting,
+        routeMode: routeMode,
+      );
     });
 
     return RepaintBoundary(

--- a/lib/ui/setting/setting_page.dart
+++ b/lib/ui/setting/setting_page.dart
@@ -39,7 +39,7 @@ class SettingPage extends HookConsumerWidget {
     );
 
     return ColoredBox(
-      color: context.theme.background,
+      color: context.theme.primary,
       child: Column(
         children: [
           const SizedBox(height: 64),

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -47,6 +47,9 @@ class MixinAppBar extends StatelessWidget implements PreferredSizeWidget {
           const SizedBox(width: 8),
         ],
         elevation: 0,
+        scrolledUnderElevation: 0,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: Colors.transparent,
         centerTitle: true,
         backgroundColor: backgroundColor ?? context.theme.primary,
         leading: MoveWindowBarrier(


### PR DESCRIPTION
## Summary
- restore the light settings list background hierarchy
- preserve the settings route after clearing the selected conversation
- prevent app bars from changing color when content scrolls

## Validation
- dart analyze --fatal-infos lib/ui/setting/setting_page.dart
- dart analyze --fatal-infos lib/widgets/app_bar.dart lib/widgets/cell.dart lib/ui/home/home.dart lib/ui/setting