### PR TITLE
fix: encode sticker uploads as base64url

### DIFF
--- a/lib/widgets/sticker_page/add_sticker_dialog.dart
+++ b/lib/widgets/sticker_page/add_sticker_dialog.dart
@@ -89,7 +89,7 @@ class _AddStickerDialog extends StatelessWidget {
 
                   final response = await accountServer.client.accountApi
                       .addSticker(
-                        StickerRequest(dataBase64: bytes.base64Encode()),
+                        StickerRequest(dataBase64: bytes.base64RawUrlEncode()),
                       );
                   final sticker = response.data;
 


### PR DESCRIPTION
## Summary
- Encode local sticker uploads with unpadded URL-safe Base64 to match the mobile clients.

## Validation
- `flutter analyze lib/widgets/sticker_page/add_sticker_dialog.dart`
- Manually verified the previously failing JPEG upload on macOS.