### PR TITLE
feat: add global remote image cache

### DIFF
--- a/lib/utils/image.dart
+++ b/lib/utils/image.dart
@@ -13,7 +13,7 @@ const _kQuality = 85;
 const _kMinGifFrameDelayCentiseconds = 2;
 const _kDefaultGifFrameDelayCentiseconds = 10;
 // ponytail: remote images above this are too risky to decode in memory.
-const _kMaxDownloadedImageBytes = 32 * 1024 * 1024;
+const maxDownloadedImageBytes = 32 * 1024 * 1024;
 
 enum ImageType { gif, jpeg, png }
 
@@ -99,7 +99,7 @@ Future<(Uint8List, ImageType, int, int)?> compressFileWithIsolate(File file) =>
 Future<File?> downloadImageFile(
   String url, {
   ProxyConfig? proxyConfig,
-  int maxBytes = _kMaxDownloadedImageBytes,
+  int maxBytes = maxDownloadedImageBytes,
 }) async {
   final resolved = Uri.base.resolve(url);
   final response = await _sendImageRequest(resolved, proxyConfig);
@@ -133,7 +133,7 @@ Future<File?> downloadImageFile(
 Future<Uint8List> downloadImageBytes(
   String url, {
   ProxyConfig? proxyConfig,
-  int maxBytes = _kMaxDownloadedImageBytes,
+  int maxBytes = maxDownloadedImageBytes,
 }) async {
   final resolved = Uri.base.resolve(url);
   final response = await _sendImageRequest(resolved, proxyConfig);

--- a/lib/widgets/global_image_cache.dart
+++ b/lib/widgets/global_image_cache.dart
@@ -1,0 +1,552 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../utils/image.dart';
+import '../utils/proxy.dart';
+
+const _kGlobalImageCacheKey = 'mixin_global_image_cache';
+const _kGlobalImageCacheMaxSizeBytes = 1024 * 1024 * 1024;
+const _kDefaultImageCacheMaxAge = Duration(days: 7);
+const _kCacheEntryFileExtension = '.image';
+
+typedef ImageCacheFetcher =
+    Future<http.StreamedResponse> Function(
+      Uri uri,
+      ProxyConfig? proxyConfig,
+      Map<String, String> headers,
+    );
+
+/// Global disk cache for visual remote images.
+///
+/// The cache is shared by every account. A cache key includes the active proxy
+/// configuration so bytes fetched through one proxy are never reused through
+/// another connection.
+class GlobalImageCache {
+  GlobalImageCache._(
+    this._directoryProvider,
+    this._fetcher,
+    this._maxSizeBytes,
+  );
+
+  @visibleForTesting
+  factory GlobalImageCache.forTesting({
+    required Directory directory,
+    required ImageCacheFetcher fetcher,
+    required int maxSizeBytes,
+  }) => GlobalImageCache._(() async => directory, fetcher, maxSizeBytes);
+
+  static final instance = GlobalImageCache._(
+    _defaultDirectory,
+    _fetchRemoteImage,
+    _kGlobalImageCacheMaxSizeBytes,
+  );
+
+  final Future<Directory> Function() _directoryProvider;
+  final ImageCacheFetcher _fetcher;
+  final int _maxSizeBytes;
+  final _entries = <String, _ImageCacheEntry>{};
+  final _refreshes = <String, Future<Uint8List?>>{};
+
+  Future<void>? _ready;
+  Future<void> _operations = Future.value();
+  var _lastTouched = DateTime.fromMillisecondsSinceEpoch(0);
+  late Directory _directory;
+  late File _indexFile;
+
+  Stream<Uint8List> getBytes(
+    String url, {
+    required bool limitBytes,
+    ProxyConfig? proxyConfig,
+  }) async* {
+    final key = _cacheKey(url, proxyConfig);
+    final cached = await _read(key);
+    if (cached != null) yield cached.bytes;
+
+    if (cached != null && cached.entry.validTill.isAfter(DateTime.now())) {
+      return;
+    }
+
+    try {
+      final fresh = await _refresh(
+        key,
+        url,
+        proxyConfig: proxyConfig,
+        eTag: cached?.entry.eTag,
+        limitBytes: limitBytes,
+      );
+      if (fresh != null &&
+          (cached == null || !listEquals(cached.bytes, fresh))) {
+        yield fresh;
+      }
+    } catch (error, stackTrace) {
+      if (cached == null) Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+
+  Uint8List? peekMemoryBytes(String url, {ProxyConfig? proxyConfig}) =>
+      _entries[_cacheKey(url, proxyConfig)]?.bytes?.target;
+
+  Future<_CachedImage?> _read(String key) async {
+    await _ensureReady();
+    return _synchronized(() async {
+      final entry = _entries[key];
+      if (entry == null) return null;
+
+      final file = _fileFor(key);
+      if (!file.existsSync()) {
+        _entries.remove(key);
+        await _writeIndex();
+        return null;
+      }
+
+      final bytes = entry.bytes?.target ?? await file.readAsBytes();
+      entry
+        ..length = bytes.length
+        ..touched = _nextTouched()
+        ..bytes = WeakReference(bytes);
+      await _touch(file, entry.touched);
+      return _CachedImage(bytes, entry);
+    });
+  }
+
+  Future<Uint8List?> _refresh(
+    String key,
+    String url, {
+    required ProxyConfig? proxyConfig,
+    required String? eTag,
+    required bool limitBytes,
+  }) {
+    final pending = _refreshes[key];
+    if (pending != null) return pending;
+
+    late final Future<Uint8List?> refresh;
+    refresh =
+        _fetchAndCache(
+          key,
+          url,
+          proxyConfig: proxyConfig,
+          eTag: eTag,
+          limitBytes: limitBytes,
+        ).whenComplete(() {
+          if (identical(_refreshes[key], refresh)) _refreshes.remove(key);
+        });
+    _refreshes[key] = refresh;
+    return refresh;
+  }
+
+  Future<Uint8List?> _fetchAndCache(
+    String key,
+    String url, {
+    required ProxyConfig? proxyConfig,
+    required String? eTag,
+    required bool limitBytes,
+  }) async {
+    final headers = <String, String>{};
+    if (eTag != null) headers[HttpHeaders.ifNoneMatchHeader] = eTag;
+    final response = await _fetcher(
+      Uri.base.resolve(url),
+      proxyConfig,
+      headers,
+    );
+    final validTill = _validTill(response.headers);
+    final doesNotStore = _doesNotStore(response.headers);
+
+    if (response.statusCode == HttpStatus.notModified) {
+      await _discardResponse(response.stream);
+      if (doesNotStore) {
+        await _remove(key);
+      } else {
+        await _updateAfterNotModified(
+          key,
+          response.headers.containsKey(HttpHeaders.cacheControlHeader)
+              ? validTill
+              : null,
+          response.headers,
+        );
+      }
+      return null;
+    }
+    if (response.statusCode != HttpStatus.ok) {
+      await _cancelResponse(response.stream);
+      throw HttpException('NetworkImage HTTP ${response.statusCode}');
+    }
+
+    final bytes = await _readResponse(response, limitBytes: limitBytes);
+    if (bytes.isEmpty) throw StateError('NetworkImage is an empty file: $url');
+
+    if (doesNotStore) {
+      await _remove(key);
+      return bytes;
+    }
+
+    await _write(
+      key,
+      bytes,
+      validTill: validTill,
+      eTag: response.headers[HttpHeaders.etagHeader],
+    );
+    return bytes;
+  }
+
+  Future<void> _updateAfterNotModified(
+    String key,
+    DateTime? validTill,
+    Map<String, String> headers,
+  ) async {
+    await _ensureReady();
+    await _synchronized(() async {
+      final entry = _entries[key];
+      if (entry == null) return;
+      entry
+        ..validTill = validTill ?? entry.validTill
+        ..touched = _nextTouched()
+        ..eTag = headers[HttpHeaders.etagHeader] ?? entry.eTag;
+      await _touch(_fileFor(key), entry.touched);
+      await _writeIndex();
+    });
+  }
+
+  Future<void> _write(
+    String key,
+    Uint8List bytes, {
+    required DateTime validTill,
+    required String? eTag,
+  }) async {
+    if (bytes.length > _maxSizeBytes) return;
+
+    await _ensureReady();
+    await _synchronized(() async {
+      final file = _fileFor(key);
+      final existing = _entries[key];
+      final existingBytes = existing?.bytes?.target;
+      if (existing != null &&
+          existingBytes != null &&
+          listEquals(existingBytes, bytes)) {
+        existing
+          ..validTill = validTill
+          ..touched = _nextTouched()
+          ..eTag = eTag
+          ..bytes = WeakReference(existingBytes);
+        await _touch(file, existing.touched);
+        await _writeIndex();
+        return;
+      }
+
+      final temporary = File('${file.path}.tmp');
+      try {
+        await temporary.writeAsBytes(bytes, flush: true);
+        try {
+          await temporary.rename(file.path);
+        } on FileSystemException {
+          if (file.existsSync()) await file.delete();
+          await temporary.rename(file.path);
+        }
+      } catch (_) {
+        if (temporary.existsSync()) await temporary.delete();
+        rethrow;
+      }
+
+      final entry = _ImageCacheEntry(
+        length: bytes.length,
+        validTill: validTill,
+        touched: _nextTouched(),
+        eTag: eTag,
+      )..bytes = WeakReference(bytes);
+      _entries[key] = entry;
+      await _touch(file, entry.touched);
+      await _trim();
+      await _writeIndex();
+    });
+  }
+
+  Future<void> _remove(String key) async {
+    await _ensureReady();
+    await _synchronized(() async {
+      final file = _fileFor(key);
+      final hadEntry = _entries.remove(key) != null;
+      if (file.existsSync()) await file.delete();
+      if (hadEntry) await _writeIndex();
+    });
+  }
+
+  Future<void> _ensureReady() => _ready ??= _initialize();
+
+  Future<void> _initialize() async {
+    _directory = await _directoryProvider();
+    await _directory.create(recursive: true);
+    _indexFile = File(p.join(_directory.path, 'index.json'));
+
+    try {
+      if (_indexFile.existsSync()) {
+        final json = jsonDecode(await _indexFile.readAsString());
+        if (json is Map<String, dynamic>) {
+          for (final MapEntry(:key, :value) in json.entries) {
+            if (!_isCacheKey(key) || value is! Map<String, dynamic>) continue;
+            final entry = _ImageCacheEntry.fromJson(value);
+            if (entry != null) {
+              _entries[key] = entry;
+              if (entry.touched.isAfter(_lastTouched)) {
+                _lastTouched = entry.touched;
+              }
+            }
+          }
+        }
+      }
+    } on Object {
+      _entries.clear();
+    }
+
+    var changed = false;
+    final knownFiles = <String>{
+      _indexFile.path,
+      for (final key in _entries.keys) _fileFor(key).path,
+    };
+    await for (final entity in _directory.list()) {
+      if (entity is File && !knownFiles.contains(entity.path)) {
+        await entity.delete();
+        changed = true;
+      }
+    }
+
+    for (final key in _entries.keys.toList()) {
+      final file = _fileFor(key);
+      if (!file.existsSync()) {
+        _entries.remove(key);
+        changed = true;
+        continue;
+      }
+      final entry = _entries[key]!;
+      final length = await file.length();
+      if (length == 0) {
+        await file.delete();
+        _entries.remove(key);
+        changed = true;
+        continue;
+      }
+      if (entry.length != length) {
+        entry.length = length;
+        changed = true;
+      }
+      final touched = file.lastModifiedSync();
+      if (touched.isAfter(entry.touched)) {
+        entry.touched = touched;
+        changed = true;
+      }
+    }
+
+    if (await _trim()) changed = true;
+    if (changed || !_indexFile.existsSync()) await _writeIndex();
+  }
+
+  Future<bool> _trim() async {
+    var changed = false;
+    var size = 0;
+    final entries = <MapEntry<String, _ImageCacheEntry>>[];
+    for (final entry in _entries.entries.toList()) {
+      final file = _fileFor(entry.key);
+      if (!file.existsSync()) {
+        _entries.remove(entry.key);
+        changed = true;
+        continue;
+      }
+      final length = await file.length();
+      if (entry.value.length != length) {
+        entry.value.length = length;
+        changed = true;
+      }
+      size += length;
+      entries.add(entry);
+    }
+
+    entries.sort((a, b) => a.value.touched.compareTo(b.value.touched));
+    for (final entry in entries) {
+      if (size <= _maxSizeBytes) break;
+      final file = _fileFor(entry.key);
+      if (file.existsSync()) await file.delete();
+      _entries.remove(entry.key);
+      size -= entry.value.length;
+      changed = true;
+    }
+    return changed;
+  }
+
+  Future<void> _writeIndex() async {
+    final temporary = File('${_indexFile.path}.tmp');
+    final json = jsonEncode(
+      _entries.map((key, entry) => MapEntry(key, entry.toJson())),
+    );
+    await temporary.writeAsString(json, flush: true);
+    try {
+      await temporary.rename(_indexFile.path);
+    } on FileSystemException {
+      if (_indexFile.existsSync()) await _indexFile.delete();
+      await temporary.rename(_indexFile.path);
+    }
+  }
+
+  File _fileFor(String key) =>
+      File(p.join(_directory.path, '$key$_kCacheEntryFileExtension'));
+
+  Future<void> _touch(File file, DateTime touched) async {
+    try {
+      await file.setLastModified(touched);
+    } on FileSystemException {
+      // Cache use must not fail if its LRU timestamp cannot be recorded.
+    }
+  }
+
+  DateTime _nextTouched() {
+    final now = DateTime.now();
+    if (now.isAfter(_lastTouched)) return _lastTouched = now;
+    return _lastTouched = _lastTouched.add(const Duration(milliseconds: 1));
+  }
+
+  Future<T> _synchronized<T>(Future<T> Function() action) {
+    final result = _operations.then((_) => action());
+    _operations = result.then<void>((_) {}, onError: (_) {});
+    return result;
+  }
+}
+
+class _CachedImage {
+  const _CachedImage(this.bytes, this.entry);
+
+  final Uint8List bytes;
+  final _ImageCacheEntry entry;
+}
+
+class _ImageCacheEntry {
+  _ImageCacheEntry({
+    required this.length,
+    required this.validTill,
+    required this.touched,
+    required this.eTag,
+  });
+
+  static _ImageCacheEntry? fromJson(Map<String, dynamic> json) {
+    final length = json['length'];
+    final validTill = json['validTill'];
+    final touched = json['touched'];
+    if (length is! int || validTill is! int || touched is! int) return null;
+    return _ImageCacheEntry(
+      length: length,
+      validTill: DateTime.fromMillisecondsSinceEpoch(validTill),
+      touched: DateTime.fromMillisecondsSinceEpoch(touched),
+      eTag: json['eTag'] as String?,
+    );
+  }
+
+  int length;
+  DateTime validTill;
+  DateTime touched;
+  String? eTag;
+  WeakReference<Uint8List>? bytes;
+
+  Map<String, Object?> toJson() => {
+    'length': length,
+    'validTill': validTill.millisecondsSinceEpoch,
+    'touched': touched.millisecondsSinceEpoch,
+    'eTag': eTag,
+  };
+}
+
+Future<Directory> _defaultDirectory() async => Directory(
+  p.join((await getApplicationCacheDirectory()).path, _kGlobalImageCacheKey),
+);
+
+Future<http.StreamedResponse> _fetchRemoteImage(
+  Uri uri,
+  ProxyConfig? proxyConfig,
+  Map<String, String> headers,
+) async => (await createRHttpClient(proxyConfig: proxyConfig)).send(
+  http.Request('GET', uri)..headers.addAll(headers),
+);
+
+Future<Uint8List> _readResponse(
+  http.StreamedResponse response, {
+  required bool limitBytes,
+}) async {
+  final limit = limitBytes ? maxDownloadedImageBytes : null;
+  if (limit != null && (response.contentLength ?? 0) > limit) {
+    await _cancelResponse(response.stream);
+    throw StateError('NetworkImage is too large');
+  }
+
+  final bytes = BytesBuilder(copy: false);
+  final header = BytesBuilder(copy: false);
+  var received = 0;
+  bool? isGif;
+
+  await for (final chunk in response.stream) {
+    if (isGif == null) {
+      final remaining = 6 - header.length;
+      if (remaining > 0) header.add(chunk.take(remaining).toList());
+      if (header.length == 6) isGif = _isGif(header.takeBytes());
+    }
+
+    received += chunk.length;
+    final maximum = limit ?? (isGif == true ? maxDownloadedImageBytes : null);
+    if (maximum != null && received > maximum) {
+      throw StateError('NetworkImage is too large');
+    }
+    bytes.add(chunk);
+  }
+
+  final data = bytes.takeBytes();
+  return isGif == true ? normalizeGifBytesIfNeeded(data) : data;
+}
+
+Future<void> _discardResponse(Stream<List<int>> stream) => stream.drain<void>();
+
+Future<void> _cancelResponse(Stream<List<int>> stream) =>
+    stream.listen((_) {}).cancel();
+
+bool _doesNotStore(Map<String, String> headers) =>
+    headers[HttpHeaders.cacheControlHeader]
+        ?.split(',')
+        .any((value) => value.trim().toLowerCase() == 'no-store') ??
+    false;
+
+DateTime _validTill(Map<String, String> headers) {
+  var duration = _kDefaultImageCacheMaxAge;
+  var mustRevalidate = false;
+  final cacheControl = headers[HttpHeaders.cacheControlHeader];
+  if (cacheControl != null) {
+    for (final setting in cacheControl.split(',')) {
+      final value = setting.trim().toLowerCase();
+      if (value == 'no-cache' || value == 'no-store') {
+        mustRevalidate = true;
+      }
+      if (value.startsWith('max-age=')) {
+        duration = Duration(
+          seconds: int.tryParse(value.substring('max-age='.length)) ?? 0,
+        );
+      }
+    }
+  }
+  return DateTime.now().add(mustRevalidate ? Duration.zero : duration);
+}
+
+bool _isCacheKey(String value) => RegExp(r'^[0-9a-f]{64}$').hasMatch(value);
+
+bool _isGif(Uint8List data) =>
+    data.length >= 6 &&
+    data[0] == 0x47 &&
+    data[1] == 0x49 &&
+    data[2] == 0x46 &&
+    data[3] == 0x38 &&
+    (data[4] == 0x37 || data[4] == 0x39) &&
+    data[5] == 0x61;
+
+String _cacheKey(String url, ProxyConfig? proxyConfig) => _hash(
+  '$url\u0000${proxyConfig == null ? 'direct' : _hash(jsonEncode(proxyConfig.toJson()))}',
+);
+
+String _hash(String value) => sha256.convert(utf8.encode(value)).toString();

--- a/lib/widgets/global_image_cache.dart
+++ b/lib/widgets/global_image_cache.dart
@@ -11,7 +11,7 @@ import 'package:path_provider/path_provider.dart';
 import '../utils/image.dart';
 import '../utils/proxy.dart';
 
-const _kGlobalImageCacheKey = 'mixin_global_image_cache';
+const _kGlobalImageCacheKey = 'cacheimage';
 const _kGlobalImageCacheMaxSizeBytes = 1024 * 1024 * 1024;
 const _kDefaultImageCacheMaxAge = Duration(days: 7);
 const _kCacheEntryFileExtension = '.image';
@@ -455,7 +455,7 @@ class _ImageCacheEntry {
 }
 
 Future<Directory> _defaultDirectory() async => Directory(
-  p.join((await getApplicationCacheDirectory()).path, _kGlobalImageCacheKey),
+  p.join((await getTemporaryDirectory()).path, _kGlobalImageCacheKey),
 );
 
 Future<http.StreamedResponse> _fetchRemoteImage(

--- a/lib/widgets/global_image_cache.dart
+++ b/lib/widgets/global_image_cache.dart
@@ -90,9 +90,6 @@ class GlobalImageCache {
     }
   }
 
-  Uint8List? peekMemoryBytes(String url, {ProxyConfig? proxyConfig}) =>
-      _entries[_cacheKey(url, proxyConfig)]?.bytes?.target;
-
   Future<_CachedImage?> _read(String key) async {
     await _ensureReady();
     return _synchronized(() async {

--- a/lib/widgets/media_image_pipeline.dart
+++ b/lib/widgets/media_image_pipeline.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -8,6 +10,17 @@ import '../utils/proxy.dart';
 import 'global_image_cache.dart';
 
 typedef PlaceholderWidgetBuilder = Widget Function();
+
+ImageProvider resolveMediaImageProvider(
+  ImageProvider image,
+  ProxyConfig? proxyConfig,
+) => image is NetworkImage
+    ? CachedNetworkImage(
+        image.url,
+        scale: image.scale,
+        proxyConfig: proxyConfig,
+      )
+    : image;
 
 final _checkedImageFiles = <String>{};
 
@@ -35,26 +48,12 @@ class MediaImagePipeline extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final image = this.image;
-    if (image is NetworkImage) {
-      return CachedMediaImage(
-        url: image.url,
-        scale: image.scale,
-        proxyConfig: proxyConfig,
-        placeholder: placeholder,
-        errorBuilder: errorBuilder,
-        width: width,
-        height: height,
-        fit: fit,
-        isAntiAlias: isAntiAlias,
-      );
-    }
-
+    final resolvedImage = resolveMediaImageProvider(image, proxyConfig);
     Widget fallback() =>
         placeholder?.call() ?? SizedBox(width: width, height: height);
 
     Widget imageView() => Image(
-      image: image,
+      image: resolvedImage,
       width: width,
       height: height,
       fit: fit,
@@ -68,112 +67,82 @@ class MediaImagePipeline extends StatelessWidget {
     );
 
     return NormalizedGifImageGate(
-      image: image,
+      image: resolvedImage,
       placeholder: fallback,
       childBuilder: imageView,
     );
   }
 }
 
-class CachedMediaImage extends StatefulWidget {
-  const CachedMediaImage({
-    required this.url,
-    required this.scale,
-    required this.proxyConfig,
-    required this.placeholder,
-    required this.errorBuilder,
-    required this.width,
-    required this.height,
-    required this.fit,
-    required this.isAntiAlias,
+@immutable
+class CachedNetworkImage extends ImageProvider<CachedNetworkImage> {
+  const CachedNetworkImage(
+    this.url, {
+    this.scale = 1.0,
+    this.proxyConfig,
     @visibleForTesting this.imageCache,
-    super.key,
   });
 
   final String url;
   final double scale;
   final ProxyConfig? proxyConfig;
-  final PlaceholderWidgetBuilder? placeholder;
-  final ImageErrorWidgetBuilder? errorBuilder;
-  final double? width;
-  final double? height;
-  final BoxFit? fit;
-  final bool isAntiAlias;
 
   @visibleForTesting
   final GlobalImageCache? imageCache;
 
-  @override
-  State<CachedMediaImage> createState() => _CachedMediaImageState();
-}
-
-class _CachedMediaImageState extends State<CachedMediaImage> {
-  late Stream<Uint8List> _images;
+  GlobalImageCache get _cache => imageCache ?? GlobalImageCache.instance;
 
   @override
-  void initState() {
-    super.initState();
-    _images = _imageStream();
-  }
+  Future<CachedNetworkImage> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<CachedNetworkImage>(this);
 
   @override
-  void didUpdateWidget(covariant CachedMediaImage oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.url != widget.url ||
-        oldWidget.proxyConfig != widget.proxyConfig ||
-        oldWidget.imageCache != widget.imageCache) {
-      _images = _imageStream();
+  ImageStreamCompleter loadImage(
+    CachedNetworkImage key,
+    ImageDecoderCallback decode,
+  ) => MultiFrameImageStreamCompleter(
+    codec: _loadAsync(key, decode),
+    scale: key.scale,
+    debugLabel: key.url,
+    informationCollector: () => <DiagnosticsNode>[
+      DiagnosticsProperty<ImageProvider>('Image provider', this),
+      DiagnosticsProperty<CachedNetworkImage>('Image key', key),
+    ],
+  );
+
+  Future<ui.Codec> _loadAsync(
+    CachedNetworkImage key,
+    Future<ui.Codec> Function(ui.ImmutableBuffer buffer) decode,
+  ) async {
+    try {
+      // ponytail: expired entries revalidate before decode; add a streaming
+      // completer only if live stale-while-revalidate updates are required.
+      final bytes = await _cache
+          .getBytes(
+            key.url,
+            proxyConfig: key.proxyConfig,
+            limitBytes: true,
+          )
+          .last;
+      return await decode(await ui.ImmutableBuffer.fromUint8List(bytes));
+    } catch (_) {
+      scheduleMicrotask(() {
+        PaintingBinding.instance.imageCache.evict(key);
+      });
+      rethrow;
     }
   }
 
-  GlobalImageCache get _cache => widget.imageCache ?? GlobalImageCache.instance;
-
-  Stream<Uint8List> _imageStream() => _cache.getBytes(
-    widget.url,
-    proxyConfig: widget.proxyConfig,
-    limitBytes: true,
-  );
+  @override
+  bool operator ==(Object other) =>
+      other is CachedNetworkImage &&
+      other.url == url &&
+      other.scale == scale &&
+      other.proxyConfig == proxyConfig &&
+      other.imageCache == imageCache;
 
   @override
-  Widget build(BuildContext context) {
-    Widget fallback() =>
-        widget.placeholder?.call() ??
-        SizedBox(width: widget.width, height: widget.height);
-
-    return StreamBuilder<Uint8List>(
-      key: ValueKey((widget.url, widget.proxyConfig, widget.imageCache)),
-      initialData: _cache.peekMemoryBytes(
-        widget.url,
-        proxyConfig: widget.proxyConfig,
-      ),
-      stream: _images,
-      builder: (context, snapshot) {
-        final error = snapshot.error;
-        if (error != null) {
-          return widget.errorBuilder?.call(context, error, StackTrace.empty) ??
-              fallback();
-        }
-        final bytes = snapshot.data;
-        if (bytes == null) return fallback();
-
-        return Image.memory(
-          bytes,
-          scale: widget.scale,
-          width: widget.width,
-          height: widget.height,
-          fit: widget.fit,
-          isAntiAlias: widget.isAntiAlias,
-          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-            if (wasSynchronouslyLoaded || frame != null) return child;
-            return fallback();
-          },
-          errorBuilder: (context, error, stackTrace) =>
-              widget.errorBuilder?.call(context, error, stackTrace) ??
-              fallback(),
-        );
-      },
-    );
-  }
+  int get hashCode => Object.hash(url, scale, proxyConfig, imageCache);
 }
 
 class NormalizedGifImageGate extends StatefulWidget {

--- a/lib/widgets/media_image_pipeline.dart
+++ b/lib/widgets/media_image_pipeline.dart
@@ -1,48 +1,15 @@
-import 'dart:async';
 import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../utils/image.dart';
 import '../utils/proxy.dart';
+import 'global_image_cache.dart';
 
 typedef PlaceholderWidgetBuilder = Widget Function();
 
 final _checkedImageFiles = <String>{};
-
-bool shouldUseMediaImagePipeline(
-  String url,
-  ProxyConfig? proxyConfig, {
-  bool normalizeGif = false,
-}) => normalizeGif || proxyConfig != null || isLikelyGifUrl(url);
-
-@visibleForTesting
-bool isLikelyGifUrl(String url) {
-  final path = Uri.tryParse(url)?.path ?? url.split('?').first;
-  return path.toLowerCase().endsWith('.gif');
-}
-
-ImageProvider resolveMediaImageProvider({
-  required ImageProvider image,
-  required ProxyConfig? proxyConfig,
-  bool normalizeGif = false,
-}) {
-  if (image is NetworkImage &&
-      shouldUseMediaImagePipeline(
-        image.url,
-        proxyConfig,
-        normalizeGif: normalizeGif,
-      )) {
-    return ProxyNetworkImage(
-      image.url,
-      scale: image.scale,
-      proxyConfig: proxyConfig,
-    );
-  }
-  return image;
-}
 
 class MediaImagePipeline extends StatelessWidget {
   const MediaImagePipeline({
@@ -55,7 +22,6 @@ class MediaImagePipeline extends StatelessWidget {
     this.height,
     this.fit = BoxFit.cover,
     this.isAntiAlias = false,
-    this.normalizeGif = false,
   });
 
   final ImageProvider image;
@@ -66,21 +32,29 @@ class MediaImagePipeline extends StatelessWidget {
   final double? height;
   final BoxFit? fit;
   final bool isAntiAlias;
-  final bool normalizeGif;
 
   @override
   Widget build(BuildContext context) {
-    final resolvedImage = resolveMediaImageProvider(
-      image: image,
-      proxyConfig: proxyConfig,
-      normalizeGif: normalizeGif,
-    );
+    final image = this.image;
+    if (image is NetworkImage) {
+      return CachedMediaImage(
+        url: image.url,
+        scale: image.scale,
+        proxyConfig: proxyConfig,
+        placeholder: placeholder,
+        errorBuilder: errorBuilder,
+        width: width,
+        height: height,
+        fit: fit,
+        isAntiAlias: isAntiAlias,
+      );
+    }
 
     Widget fallback() =>
         placeholder?.call() ?? SizedBox(width: width, height: height);
 
     Widget imageView() => Image(
-      image: resolvedImage,
+      image: image,
       width: width,
       height: height,
       fit: fit,
@@ -94,70 +68,112 @@ class MediaImagePipeline extends StatelessWidget {
     );
 
     return NormalizedGifImageGate(
-      image: resolvedImage,
+      image: image,
       placeholder: fallback,
       childBuilder: imageView,
     );
   }
 }
 
-@immutable
-class ProxyNetworkImage extends ImageProvider<ProxyNetworkImage> {
-  const ProxyNetworkImage(this.url, {this.scale = 1.0, this.proxyConfig});
+class CachedMediaImage extends StatefulWidget {
+  const CachedMediaImage({
+    required this.url,
+    required this.scale,
+    required this.proxyConfig,
+    required this.placeholder,
+    required this.errorBuilder,
+    required this.width,
+    required this.height,
+    required this.fit,
+    required this.isAntiAlias,
+    @visibleForTesting this.imageCache,
+    super.key,
+  });
 
   final String url;
   final double scale;
   final ProxyConfig? proxyConfig;
+  final PlaceholderWidgetBuilder? placeholder;
+  final ImageErrorWidgetBuilder? errorBuilder;
+  final double? width;
+  final double? height;
+  final BoxFit? fit;
+  final bool isAntiAlias;
+
+  @visibleForTesting
+  final GlobalImageCache? imageCache;
 
   @override
-  Future<ProxyNetworkImage> obtainKey(ImageConfiguration configuration) =>
-      SynchronousFuture<ProxyNetworkImage>(this);
+  State<CachedMediaImage> createState() => _CachedMediaImageState();
+}
+
+class _CachedMediaImageState extends State<CachedMediaImage> {
+  late Stream<Uint8List> _images;
 
   @override
-  ImageStreamCompleter loadImage(
-    ProxyNetworkImage key,
-    ImageDecoderCallback decode,
-  ) => _load(key, (buffer) => decode(buffer));
-
-  ImageStreamCompleter _load(
-    ProxyNetworkImage key,
-    Future<ui.Codec> Function(ui.ImmutableBuffer buffer) decode,
-  ) => MultiFrameImageStreamCompleter(
-    codec: _loadAsync(key, decode),
-    scale: key.scale,
-    debugLabel: key.url,
-    informationCollector: () => <DiagnosticsNode>[
-      DiagnosticsProperty<ImageProvider>('Image provider', this),
-      DiagnosticsProperty<ProxyNetworkImage>('Image key', key),
-    ],
-  );
-
-  Future<ui.Codec> _loadAsync(
-    ProxyNetworkImage key,
-    Future<ui.Codec> Function(ui.ImmutableBuffer buffer) decode,
-  ) async {
-    try {
-      final bytes = normalizeGifBytesIfNeeded(
-        await downloadImageBytes(key.url, proxyConfig: key.proxyConfig),
-      );
-      return await decode(await ui.ImmutableBuffer.fromUint8List(bytes));
-    } catch (_) {
-      scheduleMicrotask(() {
-        PaintingBinding.instance.imageCache.evict(key);
-      });
-      rethrow;
-    }
+  void initState() {
+    super.initState();
+    _images = _imageStream();
   }
 
   @override
-  bool operator ==(Object other) =>
-      other is ProxyNetworkImage &&
-      other.url == url &&
-      other.scale == scale &&
-      other.proxyConfig == proxyConfig;
+  void didUpdateWidget(covariant CachedMediaImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.url != widget.url ||
+        oldWidget.proxyConfig != widget.proxyConfig ||
+        oldWidget.imageCache != widget.imageCache) {
+      _images = _imageStream();
+    }
+  }
+
+  GlobalImageCache get _cache => widget.imageCache ?? GlobalImageCache.instance;
+
+  Stream<Uint8List> _imageStream() => _cache.getBytes(
+    widget.url,
+    proxyConfig: widget.proxyConfig,
+    limitBytes: true,
+  );
 
   @override
-  int get hashCode => Object.hash(url, scale, proxyConfig);
+  Widget build(BuildContext context) {
+    Widget fallback() =>
+        widget.placeholder?.call() ??
+        SizedBox(width: widget.width, height: widget.height);
+
+    return StreamBuilder<Uint8List>(
+      key: ValueKey((widget.url, widget.proxyConfig, widget.imageCache)),
+      initialData: _cache.peekMemoryBytes(
+        widget.url,
+        proxyConfig: widget.proxyConfig,
+      ),
+      stream: _images,
+      builder: (context, snapshot) {
+        final error = snapshot.error;
+        if (error != null) {
+          return widget.errorBuilder?.call(context, error, StackTrace.empty) ??
+              fallback();
+        }
+        final bytes = snapshot.data;
+        if (bytes == null) return fallback();
+
+        return Image.memory(
+          bytes,
+          scale: widget.scale,
+          width: widget.width,
+          height: widget.height,
+          fit: widget.fit,
+          isAntiAlias: widget.isAntiAlias,
+          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+            if (wasSynchronouslyLoaded || frame != null) return child;
+            return fallback();
+          },
+          errorBuilder: (context, error, stackTrace) =>
+              widget.errorBuilder?.call(context, error, stackTrace) ??
+              fallback(),
+        );
+      },
+    );
+  }
 }
 
 class NormalizedGifImageGate extends StatefulWidget {

--- a/lib/widgets/mixin_image.dart
+++ b/lib/widgets/mixin_image.dart
@@ -16,7 +16,6 @@ class MixinImage extends StatelessWidget {
     this.height,
     this.fit = BoxFit.cover,
     this.isAntiAlias = false,
-    this.normalizeGif = false,
   });
 
   MixinImage.network(
@@ -28,7 +27,6 @@ class MixinImage extends StatelessWidget {
     this.height,
     this.fit = BoxFit.cover,
     this.isAntiAlias = false,
-    this.normalizeGif = false,
   }) : image = NetworkImage(url);
 
   MixinImage.file(
@@ -40,8 +38,7 @@ class MixinImage extends StatelessWidget {
     this.height,
     this.fit = BoxFit.cover,
     this.isAntiAlias = false,
-  }) : image = FileImage(file),
-       normalizeGif = false;
+  }) : image = FileImage(file);
 
   MixinImage.asset(
     String assetName, {
@@ -52,8 +49,7 @@ class MixinImage extends StatelessWidget {
     this.height,
     this.fit = BoxFit.cover,
     this.isAntiAlias = false,
-  }) : image = AssetImage(assetName),
-       normalizeGif = false;
+  }) : image = AssetImage(assetName);
 
   MixinImage.memory(
     Uint8List bytes, {
@@ -64,8 +60,7 @@ class MixinImage extends StatelessWidget {
     this.height,
     this.fit = BoxFit.cover,
     this.isAntiAlias = false,
-  }) : image = MemoryImage(bytes),
-       normalizeGif = false;
+  }) : image = MemoryImage(bytes);
 
   final ImageProvider image;
   final PlaceholderWidgetBuilder? placeholder;
@@ -74,7 +69,6 @@ class MixinImage extends StatelessWidget {
   final double? height;
   final BoxFit? fit;
   final bool isAntiAlias;
-  final bool normalizeGif;
 
   @override
   Widget build(BuildContext context) => MediaImagePipeline(
@@ -86,6 +80,5 @@ class MixinImage extends StatelessWidget {
     height: height,
     fit: fit,
     isAntiAlias: isAntiAlias,
-    normalizeGif: normalizeGif,
   );
 }

--- a/lib/widgets/sticker_page/sticker_item.dart
+++ b/lib/widgets/sticker_page/sticker_item.dart
@@ -111,7 +111,6 @@ class StickerItem extends HookConsumerWidget {
             height: height,
             width: width,
             fit: BoxFit.contain,
-            normalizeGif: assetType?.toLowerCase() == 'gif',
             errorBuilder: (context, error, stackTrace) {
               _triggerRefreshJob(context, stickerId);
               return errorWidget ?? const SizedBox();

--- a/test/widgets/global_image_cache_test.dart
+++ b/test/widgets/global_image_cache_test.dart
@@ -1,0 +1,430 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_app/utils/image.dart';
+import 'package:flutter_app/utils/proxy.dart';
+import 'package:flutter_app/widgets/global_image_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  test('uses the disk cache after recreation', () async {
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    final fetcher = _ImageFetcher([
+      _ResponseData(Uint8List.fromList([1, 2, 3]), maxAge: 1),
+    ]);
+
+    final first = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher.call,
+      maxSizeBytes: 1024,
+    );
+    expect(
+      await first
+          .getBytes('https://example.com/image.png', limitBytes: false)
+          .single,
+      [1, 2, 3],
+    );
+
+    final second = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher.call,
+      maxSizeBytes: 1024,
+    );
+    expect(
+      await second
+          .getBytes('https://example.com/image.png', limitBytes: false)
+          .single,
+      [1, 2, 3],
+    );
+    expect(fetcher.calls, 1);
+  });
+
+  test('does not persist no-store responses', () async {
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    final fetcher = _ImageFetcher([
+      _ResponseData(Uint8List.fromList([1]), maxAge: 0),
+      _ResponseData(Uint8List.fromList([2]), maxAge: 0, noStore: true),
+      _ResponseData(Uint8List.fromList([3]), maxAge: 1),
+    ]);
+    final cache = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher.call,
+      maxSizeBytes: 1024,
+    );
+
+    expect(
+      await cache
+          .getBytes('https://example.com/image.png', limitBytes: false)
+          .single,
+      [1],
+    );
+    expect(
+      await cache
+          .getBytes('https://example.com/image.png', limitBytes: false)
+          .toList(),
+      [
+        [1],
+        [2],
+      ],
+    );
+
+    final restarted = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher.call,
+      maxSizeBytes: 1024,
+    );
+    expect(
+      await restarted
+          .getBytes('https://example.com/image.png', limitBytes: false)
+          .single,
+      [3],
+    );
+    expect(fetcher.calls, 3);
+  });
+
+  test(
+    'revalidates no-cache responses regardless of directive order',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'image-cache-test',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final fetcher = _ImageFetcher([
+        _ResponseData(
+          Uint8List.fromList([1]),
+          maxAge: 0,
+          cacheControl: 'no-cache, max-age=3600',
+          eTag: 'one',
+        ),
+        _ResponseData(Uint8List.fromList([2]), maxAge: 1),
+      ]);
+      final cache = GlobalImageCache.forTesting(
+        directory: directory,
+        fetcher: fetcher.call,
+        maxSizeBytes: 1024,
+      );
+
+      expect(
+        await cache
+            .getBytes('https://example.com/image.png', limitBytes: false)
+            .single,
+        [1],
+      );
+      expect(
+        await cache
+            .getBytes('https://example.com/image.png', limitBytes: false)
+            .toList(),
+        [
+          [1],
+          [2],
+        ],
+      );
+      expect(fetcher.headers.last[HttpHeaders.ifNoneMatchHeader], 'one');
+    },
+  );
+
+  test(
+    'keeps no-cache revalidation after a 304 without cache control',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'image-cache-test',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final fetcher = _ImageFetcher([
+        _ResponseData(
+          Uint8List.fromList([1]),
+          maxAge: 0,
+          cacheControl: 'no-cache, max-age=3600',
+          eTag: 'one',
+        ),
+        _ResponseData(
+          Uint8List(0),
+          maxAge: 0,
+          statusCode: HttpStatus.notModified,
+          omitCacheControl: true,
+        ),
+        _ResponseData(Uint8List.fromList([2]), maxAge: 1),
+      ]);
+      final cache = GlobalImageCache.forTesting(
+        directory: directory,
+        fetcher: fetcher.call,
+        maxSizeBytes: 1024,
+      );
+
+      expect(
+        await cache
+            .getBytes('https://example.com/image.png', limitBytes: false)
+            .single,
+        [1],
+      );
+      expect(
+        await cache
+            .getBytes('https://example.com/image.png', limitBytes: false)
+            .toList(),
+        [
+          [1],
+        ],
+      );
+      expect(
+        await cache
+            .getBytes('https://example.com/image.png', limitBytes: false)
+            .toList(),
+        [
+          [1],
+          [2],
+        ],
+      );
+      expect(fetcher.headers[1][HttpHeaders.ifNoneMatchHeader], 'one');
+      expect(fetcher.headers[2][HttpHeaders.ifNoneMatchHeader], 'one');
+    },
+  );
+
+  test('keeps proxy responses separate from direct responses', () async {
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    final fetcher = _ImageFetcher([
+      _ResponseData(Uint8List.fromList([1]), maxAge: 1),
+      _ResponseData(Uint8List.fromList([2]), maxAge: 1),
+    ]);
+    final cache = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher.call,
+      maxSizeBytes: 1024,
+    );
+
+    expect(
+      await cache
+          .getBytes('https://example.com/image.png', limitBytes: false)
+          .single,
+      [1],
+    );
+    expect(
+      await cache
+          .getBytes(
+            'https://example.com/image.png',
+            limitBytes: true,
+            proxyConfig: ProxyConfig(
+              type: ProxyType.http,
+              host: '127.0.0.1',
+              port: 8080,
+              id: 'test',
+            ),
+          )
+          .single,
+      [2],
+    );
+    expect(fetcher.calls, 2);
+  });
+
+  test('emits a stale file before revalidating it', () async {
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    final fetcher = _ImageFetcher([
+      _ResponseData(Uint8List.fromList([1]), maxAge: 0, eTag: 'one'),
+      _ResponseData(Uint8List.fromList([2]), maxAge: 1, eTag: 'two'),
+    ]);
+    final cache = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher.call,
+      maxSizeBytes: 1024,
+    );
+
+    await cache
+        .getBytes('https://example.com/image.png', limitBytes: false)
+        .single;
+    expect(
+      await cache
+          .getBytes('https://example.com/image.png', limitBytes: false)
+          .toList(),
+      [
+        [1],
+        [2],
+      ],
+    );
+    expect(fetcher.calls, 2);
+    expect(fetcher.headers.last[HttpHeaders.ifNoneMatchHeader], 'one');
+  });
+
+  test('keeps the image bytes when revalidation is unchanged', () async {
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    final fetcher = _ImageFetcher([
+      _ResponseData(Uint8List.fromList([1]), maxAge: 0),
+      _ResponseData(Uint8List.fromList([1]), maxAge: 1),
+    ]);
+    final cache = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher.call,
+      maxSizeBytes: 1024,
+    );
+
+    final original = await cache
+        .getBytes('https://example.com/image.png', limitBytes: true)
+        .single;
+    expect(
+      await cache
+          .getBytes('https://example.com/image.png', limitBytes: true)
+          .toList(),
+      [
+        [1],
+      ],
+    );
+    expect(
+      identical(
+        original,
+        await cache
+            .getBytes('https://example.com/image.png', limitBytes: true)
+            .single,
+      ),
+      isTrue,
+    );
+  });
+
+  test('cancels failed response streams', () async {
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    var cancelled = false;
+    final response = StreamController<List<int>>(
+      onCancel: () => cancelled = true,
+    );
+    final cache = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: (_, _, _) async => http.StreamedResponse(
+        response.stream,
+        HttpStatus.internalServerError,
+      ),
+      maxSizeBytes: 1024,
+    );
+
+    await expectLater(
+      cache
+          .getBytes('https://example.com/image.png', limitBytes: false)
+          .drain<void>(),
+      throwsA(isA<HttpException>()),
+    );
+    expect(cancelled, isTrue);
+  });
+
+  test('rejects oversized responses before buffering', () async {
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    var cancelled = false;
+    final response = StreamController<List<int>>(
+      onCancel: () => cancelled = true,
+    );
+    final cache = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: (_, _, _) async => http.StreamedResponse(
+        response.stream,
+        HttpStatus.ok,
+        contentLength: maxDownloadedImageBytes + 1,
+      ),
+      maxSizeBytes: 1024,
+    );
+
+    await expectLater(
+      cache
+          .getBytes('https://example.com/image.png', limitBytes: true)
+          .drain<void>(),
+      throwsA(isA<StateError>()),
+    );
+    expect(cancelled, isTrue);
+  });
+
+  test('evicts the least recently used files over the byte limit', () async {
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    final fetcher = _ImageFetcher([
+      _ResponseData(Uint8List.fromList([1, 1, 1, 1]), maxAge: 1),
+      _ResponseData(Uint8List.fromList([2, 2, 2, 2]), maxAge: 1),
+      _ResponseData(Uint8List.fromList([3, 3, 3, 3]), maxAge: 1),
+      _ResponseData(Uint8List.fromList([4, 4, 4, 4]), maxAge: 1),
+    ]);
+    final cache = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher.call,
+      maxSizeBytes: 8,
+    );
+
+    await cache
+        .getBytes('https://example.com/first.png', limitBytes: false)
+        .single;
+    await cache
+        .getBytes('https://example.com/second.png', limitBytes: false)
+        .single;
+    await cache
+        .getBytes('https://example.com/first.png', limitBytes: false)
+        .single;
+
+    final restarted = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher.call,
+      maxSizeBytes: 8,
+    );
+    await restarted
+        .getBytes('https://example.com/third.png', limitBytes: false)
+        .single;
+
+    await restarted
+        .getBytes('https://example.com/first.png', limitBytes: false)
+        .single;
+    expect(fetcher.calls, 3);
+    await restarted
+        .getBytes('https://example.com/second.png', limitBytes: false)
+        .single;
+    expect(fetcher.calls, 4);
+  });
+}
+
+class _ImageFetcher {
+  _ImageFetcher(this._responses);
+
+  final List<_ResponseData> _responses;
+  final headers = <Map<String, String>>[];
+  int calls = 0;
+
+  Future<http.StreamedResponse> call(
+    Uri uri,
+    ProxyConfig? proxyConfig,
+    Map<String, String> requestHeaders,
+  ) async {
+    calls++;
+    headers.add(requestHeaders);
+    final response = _responses.removeAt(0);
+    return http.StreamedResponse(
+      Stream.value(response.bytes),
+      response.statusCode,
+      headers: {
+        if (!response.omitCacheControl)
+          HttpHeaders.cacheControlHeader:
+              response.cacheControl ??
+              (response.noStore ? 'no-store' : 'max-age=${response.maxAge}'),
+        if (response.eTag != null) HttpHeaders.etagHeader: response.eTag!,
+      },
+    );
+  }
+}
+
+class _ResponseData {
+  const _ResponseData(
+    this.bytes, {
+    required this.maxAge,
+    this.eTag,
+    this.noStore = false,
+    this.cacheControl,
+    this.statusCode = HttpStatus.ok,
+    this.omitCacheControl = false,
+  });
+
+  final Uint8List bytes;
+  final int maxAge;
+  final String? eTag;
+  final bool noStore;
+  final String? cacheControl;
+  final int statusCode;
+  final bool omitCacheControl;
+}

--- a/test/widgets/media_image_pipeline_test.dart
+++ b/test/widgets/media_image_pipeline_test.dart
@@ -1,69 +1,87 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_app/utils/proxy.dart';
+import 'package:flutter_app/widgets/global_image_cache.dart';
 import 'package:flutter_app/widgets/media_image_pipeline.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:image/image.dart' as img;
 
 void main() {
-  test('uses custom media pipeline only for proxy or likely gif urls', () {
-    expect(
-      shouldUseMediaImagePipeline('https://example.com/a.png', null),
-      false,
-    );
-    expect(
-      shouldUseMediaImagePipeline('https://example.com/a.gif?x=1', null),
-      true,
-    );
-    expect(
-      shouldUseMediaImagePipeline(
-        'https://example.com/no-extension',
-        null,
-        normalizeGif: true,
-      ),
-      true,
-    );
-    expect(
-      shouldUseMediaImagePipeline(
-        'https://example.com/a.png',
-        ProxyConfig(
-          type: ProxyType.http,
-          host: '127.0.0.1',
-          port: 8080,
-          id: 'test',
+  testWidgets('shows a resident remote image without its placeholder', (
+    tester,
+  ) async {
+    const url = 'https://example.com/avatar.png';
+    final image = img.Image(width: 1, height: 1)
+      ..setPixelRgba(0, 0, 0, 0, 0, 255);
+    final data = Uint8List.fromList(img.encodePng(image));
+    late Directory directory;
+    late GlobalImageCache cache;
+    late Uint8List bytes;
+    await tester.runAsync(() async {
+      directory = await Directory.systemTemp.createTemp('image-cache-test');
+      cache = GlobalImageCache.forTesting(
+        directory: directory,
+        fetcher: (_, _, _) async => http.StreamedResponse(
+          Stream.value(data),
+          HttpStatus.ok,
+          headers: {HttpHeaders.cacheControlHeader: 'max-age=3600'},
         ),
+        maxSizeBytes: 1024,
+      );
+      bytes = await cache.getBytes(url, limitBytes: true).single;
+    });
+    addTearDown(() => directory.deleteSync(recursive: true));
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(),
       ),
-      true,
     );
+    await tester.runAsync(
+      () => precacheImage(
+        MemoryImage(bytes),
+        tester.element(find.byType(SizedBox)),
+      ),
+    );
+    await tester.pump();
+
+    Widget imageFor(String imageUrl) => Directionality(
+      textDirection: TextDirection.ltr,
+      child: CachedMediaImage(
+        url: imageUrl,
+        scale: 1,
+        proxyConfig: null,
+        placeholder: () => const SizedBox(key: Key('placeholder')),
+        errorBuilder: null,
+        width: null,
+        height: null,
+        fit: null,
+        isAntiAlias: false,
+        imageCache: cache,
+      ),
+    );
+
+    await tester.pumpWidget(imageFor(url));
+    expect(find.byKey(const Key('placeholder')), findsNothing);
+
+    await tester.pumpWidget(imageFor('https://example.com/other.png'));
+    expect(find.byKey(const Key('placeholder')), findsOneWidget);
   });
 
-  test('resolves network image provider only when pipeline is needed', () {
-    const png = NetworkImage('https://example.com/a.png');
-    expect(
-      resolveMediaImageProvider(image: png, proxyConfig: null),
-      same(png),
-    );
-
-    expect(
-      resolveMediaImageProvider(
-        image: const NetworkImage('https://example.com/a.gif'),
-        proxyConfig: null,
-      ),
-      isA<ProxyNetworkImage>(),
-    );
-
-    expect(
-      resolveMediaImageProvider(
-        image: const NetworkImage('https://example.com/a.png'),
-        proxyConfig: ProxyConfig(
-          type: ProxyType.http,
-          host: '127.0.0.1',
-          port: 8080,
-          id: 'test',
+  testWidgets('keeps file images out of the global cache', (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaImagePipeline(
+          image: FileImage(File.fromUri(Uri())),
         ),
       ),
-      isA<ProxyNetworkImage>(),
     );
+
+    expect(find.byType(CachedMediaImage), findsNothing);
   });
 
   testWidgets('skips file images with empty paths', (tester) async {

--- a/test/widgets/media_image_pipeline_test.dart
+++ b/test/widgets/media_image_pipeline_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -9,69 +10,126 @@ import 'package:http/http.dart' as http;
 import 'package:image/image.dart' as img;
 
 void main() {
-  testWidgets('shows a resident remote image without its placeholder', (
-    tester,
-  ) async {
+  test('uses a cached provider for NetworkImage', () {
+    const url = 'https://example.com/avatar.png';
+    final resolved = resolveMediaImageProvider(
+      const NetworkImage(url, scale: 2),
+      null,
+    );
+
+    expect(resolved, isA<CachedNetworkImage>());
+    final image = resolved as CachedNetworkImage;
+    expect(image.url, url);
+    expect(image.scale, 2);
+  });
+
+  test('reuses decoded and persistent remote image caches', () async {
     const url = 'https://example.com/avatar.png';
     final image = img.Image(width: 1, height: 1)
       ..setPixelRgba(0, 0, 0, 0, 0, 255);
-    final data = Uint8List.fromList(img.encodePng(image));
-    late Directory directory;
-    late GlobalImageCache cache;
-    late Uint8List bytes;
-    await tester.runAsync(() async {
-      directory = await Directory.systemTemp.createTemp('image-cache-test');
-      cache = GlobalImageCache.forTesting(
-        directory: directory,
-        fetcher: (_, _, _) async => http.StreamedResponse(
-          Stream.value(data),
-          HttpStatus.ok,
-          headers: {HttpHeaders.cacheControlHeader: 'max-age=3600'},
-        ),
-        maxSizeBytes: 1024,
+    final bytes = Uint8List.fromList(img.encodePng(image));
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    var calls = 0;
+    Future<http.StreamedResponse> fetcher(_, _, _) async {
+      calls += 1;
+      return http.StreamedResponse(
+        Stream.value(bytes),
+        HttpStatus.ok,
+        headers: {HttpHeaders.cacheControlHeader: 'max-age=3600'},
       );
-      bytes = await cache.getBytes(url, limitBytes: true).single;
-    });
-    addTearDown(() => directory.deleteSync(recursive: true));
+    }
 
-    await tester.pumpWidget(
-      const Directionality(
-        textDirection: TextDirection.ltr,
-        child: SizedBox(),
-      ),
+    final cache = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher,
+      maxSizeBytes: 1024,
     );
-    await tester.runAsync(
-      () => precacheImage(
-        MemoryImage(bytes),
-        tester.element(find.byType(SizedBox)),
-      ),
+    final first = CachedNetworkImage(url, imageCache: cache);
+    expect((await _resolveImage(first)).synchronouslyLoaded, isFalse);
+    expect(calls, 1);
+
+    expect(
+      (await _resolveImage(
+        CachedNetworkImage(url, imageCache: cache),
+      )).synchronouslyLoaded,
+      isTrue,
     );
-    await tester.pump();
+    expect(calls, 1);
 
-    Widget imageFor(String imageUrl) => Directionality(
-      textDirection: TextDirection.ltr,
-      child: CachedMediaImage(
-        url: imageUrl,
-        scale: 1,
-        proxyConfig: null,
-        placeholder: () => const SizedBox(key: Key('placeholder')),
-        errorBuilder: null,
-        width: null,
-        height: null,
-        fit: null,
-        isAntiAlias: false,
-        imageCache: cache,
-      ),
+    final restartedCache = GlobalImageCache.forTesting(
+      directory: directory,
+      fetcher: fetcher,
+      maxSizeBytes: 1024,
     );
-
-    await tester.pumpWidget(imageFor(url));
-    expect(find.byKey(const Key('placeholder')), findsNothing);
-
-    await tester.pumpWidget(imageFor('https://example.com/other.png'));
-    expect(find.byKey(const Key('placeholder')), findsOneWidget);
+    await _resolveImage(CachedNetworkImage(url, imageCache: restartedCache));
+    expect(calls, 1);
   });
 
-  testWidgets('keeps file images out of the global cache', (tester) async {
+  test('uses revalidated bytes for a stale source cache', () async {
+    const url = 'https://example.com/avatar.png';
+    final original = img.Image(width: 1, height: 1);
+    final fresh = img.Image(width: 2, height: 1);
+    final directory = await Directory.systemTemp.createTemp('image-cache-test');
+    addTearDown(() => directory.delete(recursive: true));
+    final requestHeaders = <Map<String, String>>[];
+    var calls = 0;
+    Future<http.StreamedResponse> fetcher(
+      _,
+      _,
+      Map<String, String> headers,
+    ) async {
+      requestHeaders.add(Map<String, String>.of(headers));
+      switch (calls++) {
+        case 0:
+          return http.StreamedResponse(
+            Stream.value(Uint8List.fromList(img.encodePng(original))),
+            HttpStatus.ok,
+            headers: {
+              HttpHeaders.cacheControlHeader: 'no-cache',
+              HttpHeaders.etagHeader: 'one',
+            },
+          );
+        case 1:
+          return http.StreamedResponse(
+            Stream.value(Uint8List(0)),
+            HttpStatus.notModified,
+          );
+        default:
+          return http.StreamedResponse(
+            Stream.value(Uint8List.fromList(img.encodePng(fresh))),
+            HttpStatus.ok,
+            headers: {
+              HttpHeaders.cacheControlHeader: 'max-age=3600',
+              HttpHeaders.etagHeader: 'two',
+            },
+          );
+      }
+    }
+
+    Future<_ResolvedImage> loadWithNewCache() => _resolveImage(
+      CachedNetworkImage(
+        url,
+        imageCache: GlobalImageCache.forTesting(
+          directory: directory,
+          fetcher: fetcher,
+          maxSizeBytes: 1024,
+        ),
+      ),
+    );
+
+    expect((await loadWithNewCache()).width, 1);
+    expect((await loadWithNewCache()).width, 1);
+    expect(requestHeaders[1][HttpHeaders.ifNoneMatchHeader], 'one');
+    expect((await loadWithNewCache()).width, 2);
+    expect(requestHeaders[2][HttpHeaders.ifNoneMatchHeader], 'one');
+    expect((await loadWithNewCache()).width, 2);
+    expect(calls, 3);
+  });
+
+  testWidgets('keeps file images out of the remote image provider', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -81,7 +139,10 @@ void main() {
       ),
     );
 
-    expect(find.byType(CachedMediaImage), findsNothing);
+    expect(
+      tester.widget<Image>(find.byType(Image)).image,
+      isNot(isA<CachedNetworkImage>()),
+    );
   });
 
   testWidgets('skips file images with empty paths', (tester) async {
@@ -99,4 +160,39 @@ void main() {
     expect(find.byKey(const Key('child')), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
+}
+
+Future<_ResolvedImage> _resolveImage(ImageProvider image) {
+  final stream = image.resolve(ImageConfiguration.empty);
+  final completer = Completer<_ResolvedImage>();
+  late ImageStreamListener listener;
+  listener = ImageStreamListener(
+    (image, synchronouslyLoaded) {
+      final width = image.image.width;
+      image.dispose();
+      stream.removeListener(listener);
+      completer.complete(
+        _ResolvedImage(
+          width: width,
+          synchronouslyLoaded: synchronouslyLoaded,
+        ),
+      );
+    },
+    onError: (error, stackTrace) {
+      stream.removeListener(listener);
+      completer.completeError(error, stackTrace);
+    },
+  );
+  stream.addListener(listener);
+  return completer.future;
+}
+
+class _ResolvedImage {
+  const _ResolvedImage({
+    required this.width,
+    required this.synchronouslyLoaded,
+  });
+
+  final int width;
+  final bool synchronouslyLoaded;
 }


### PR DESCRIPTION
## Summary
- Persist remote image bytes across app restarts in a proxy-isolated 1 GiB LRU cache.
- Load cached remote bytes through `CachedNetworkImage`, so Flutter's `ImageCache` owns decoded-image reuse in process.
- Revalidate expired source entries with Cache-Control and ETags; honor `no-store`.

## Cache behavior
- A decoded `ImageCache` hit is not revalidated. After an app restart or Flutter eviction, the next source load reuses a valid disk file or validates an expired one.
- Local files and attachments stay outside the remote cache.

## Related
- Restores the `ImageProvider` loading path from #1995 while retaining persistent byte caching.

## Validation
- `flutter analyze lib/widgets/global_image_cache.dart lib/widgets/media_image_pipeline.dart lib/widgets/mixin_image.dart lib/widgets/sticker_page/sticker_item.dart test/widgets/global_image_cache_test.dart test/widgets/media_image_pipeline_test.dart test/utils/image_test.dart`
- `flutter test test/widgets/global_image_cache_test.dart test/widgets/media_image_pipeline_test.dart test/utils/image_test.dart`
- macOS hot restart with no runtime errors
