### PR TITLE
fix: restore preview keyboard dismissal and context menu

### DIFF
--- a/lib/widgets/message/item/image/image_message.dart
+++ b/lib/widgets/message/item/image/image_message.dart
@@ -75,6 +75,7 @@ class MessageImage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isTranscriptPage = useIsTranscriptPage();
+    final isPinnedPage = useIsPinnedPage();
     final type = useMessageConverter(converter: (state) => state.type);
     final conversationId = useMessageConverter(
       converter: (state) => state.conversationId,
@@ -141,6 +142,7 @@ class MessageImage extends HookConsumerWidget {
               conversationId: message.conversationId,
               messageId: message.messageId,
               isTranscriptPage: isTranscriptPage,
+              isPinnedPage: isPinnedPage,
             );
           case MediaStatus.canceled:
             if (message.mediaUrl?.isNotEmpty == true && isMessageSentOut) {

--- a/lib/widgets/message/item/image/image_preview_page.dart
+++ b/lib/widgets/message/item/image/image_preview_page.dart
@@ -22,6 +22,7 @@ import '../../../interactive_decorated_box.dart';
 import '../../../menu.dart';
 import '../../../user_selector/conversation_selector.dart';
 import '../../message.dart';
+import '../../message_actions_menu.dart';
 import '../transcript_message.dart';
 import 'preview_image_widget.dart';
 
@@ -30,23 +31,27 @@ class ImagePreviewPage extends HookConsumerWidget {
     required this.conversationId,
     required this.messageId,
     required this.isTranscriptPage,
+    this.isPinnedPage = false,
     super.key,
   });
 
   final String conversationId;
   final String messageId;
   final bool isTranscriptPage;
+  final bool isPinnedPage;
 
   static Future<void> push(
     BuildContext context, {
     required String conversationId,
     required String messageId,
     bool isTranscriptPage = false,
+    bool isPinnedPage = false,
   }) => showGeneralDialog(
     context: context,
     barrierColor: Colors.transparent,
     barrierDismissible: true,
     barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    requestFocus: true,
     pageBuilder:
         (
           buildContext,
@@ -57,6 +62,7 @@ class ImagePreviewPage extends HookConsumerWidget {
             conversationId: conversationId,
             messageId: messageId,
             isTranscriptPage: isTranscriptPage,
+            isPinnedPage: isPinnedPage,
           );
 
           try {
@@ -76,6 +82,8 @@ class ImagePreviewPage extends HookConsumerWidget {
     final current = useState<MessageItem?>(null);
     final prev = useState<MessageItem?>(null);
     final next = useState<MessageItem?>(null);
+    final showedMenu = useState(false);
+    final focusNode = useFocusNode(debugLabel: 'image_preview');
 
     final controller = useMemoized(TransformImageController.new, [
       current.value?.messageId,
@@ -174,8 +182,10 @@ class ImagePreviewPage extends HookConsumerWidget {
       [conversationId],
     );
 
-    return FocusableActionDetector(
+    final child = FocusableActionDetector(
+      focusNode: focusNode,
       shortcuts: {
+        const SingleActivator(LogicalKeyboardKey.escape): const _EscapeIntent(),
         SingleActivator(
           LogicalKeyboardKey.keyC,
           meta: kPlatformIsDarwin,
@@ -206,6 +216,9 @@ class ImagePreviewPage extends HookConsumerWidget {
         ): const _ImageRotateIntent(),
       },
       actions: {
+        _EscapeIntent: CallbackAction<Intent>(
+          onInvoke: (intent) => Navigator.maybePop(context),
+        ),
         _CopyIntent: CallbackAction<Intent>(
           onInvoke: (intent) => copyFile(
             context.accountServer.convertMessageAbsolutePath(
@@ -319,6 +332,26 @@ class ImagePreviewPage extends HookConsumerWidget {
           ),
         ),
       ),
+    );
+    if (!kPlatformIsDesktop) return child;
+    return CustomContextMenuWidget(
+      hitTestBehavior: HitTestBehavior.translucent,
+      menuProvider: (request) {
+        final message = current.value;
+        if (message == null) return null;
+        return buildMessageActionsMenu(
+          context: context,
+          ref: ref,
+          request: request,
+          message: message,
+          isTranscriptPage: isTranscriptPage,
+          isPinnedPage: isPinnedPage,
+          showedMenu: showedMenu,
+          focusNode: focusNode,
+        );
+      },
+      desktopMenuWidgetBuilder: CustomDesktopMenuWidgetBuilder(),
+      child: child,
     );
   }
 }
@@ -621,4 +654,8 @@ class _ImageZoomOutIntent extends Intent {
 
 class _ImageRotateIntent extends Intent {
   const _ImageRotateIntent();
+}
+
+class _EscapeIntent extends Intent {
+  const _EscapeIntent();
 }

--- a/lib/widgets/message/item/post_message.dart
+++ b/lib/widgets/message/item/post_message.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -147,6 +148,7 @@ class PostPreview extends StatelessWidget {
     barrierColor: Colors.transparent,
     barrierDismissible: true,
     barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    requestFocus: true,
     pageBuilder:
         (
           buildContext,
@@ -161,26 +163,41 @@ class PostPreview extends StatelessWidget {
   final MessageItem message;
 
   @override
-  Widget build(BuildContext context) => Material(
-    color: context.theme.background,
-    child: Column(
-      children: [
-        MixinAppBar(
-          leading: const SizedBox(),
-          actions: [MixinCloseButton(onTap: () => Navigator.pop(context))],
-        ),
-        Expanded(
-          child: Markdown(
-            data: message.content ?? '',
-            cacheKey: buildMarkdownCacheKey(
-              namespace: 'post-preview',
-              id: message.messageId,
-            ),
-            maxContentWidth: double.infinity,
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 32),
+  Widget build(BuildContext context) => FocusableActionDetector(
+    shortcuts: const {
+      SingleActivator(LogicalKeyboardKey.escape): _PostPreviewEscapeIntent(),
+    },
+    actions: {
+      _PostPreviewEscapeIntent: CallbackAction<Intent>(
+        onInvoke: (intent) => Navigator.maybePop(context),
+      ),
+    },
+    autofocus: true,
+    child: Material(
+      color: context.theme.background,
+      child: Column(
+        children: [
+          MixinAppBar(
+            leading: const SizedBox(),
+            actions: [MixinCloseButton(onTap: () => Navigator.pop(context))],
           ),
-        ),
-      ],
+          Expanded(
+            child: Markdown(
+              data: message.content ?? '',
+              cacheKey: buildMarkdownCacheKey(
+                namespace: 'post-preview',
+                id: message.messageId,
+              ),
+              maxContentWidth: double.infinity,
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 32),
+            ),
+          ),
+        ],
+      ),
     ),
   );
+}
+
+class _PostPreviewEscapeIntent extends Intent {
+  const _PostPreviewEscapeIntent();
 }

--- a/test/widgets/message/image_preview_page_test.dart
+++ b/test/widgets/message/image_preview_page_test.dart
@@ -1,0 +1,139 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_app/constants/brightness_theme_data.dart';
+import 'package:flutter_app/db/database.dart';
+import 'package:flutter_app/db/fts_database.dart';
+import 'package:flutter_app/db/mixin_database.dart';
+import 'package:flutter_app/enum/message_category.dart';
+import 'package:flutter_app/ui/provider/database_provider.dart';
+import 'package:flutter_app/ui/provider/setting_provider.dart';
+import 'package:flutter_app/utils/event_bus.dart';
+import 'package:flutter_app/widgets/brightness_observer.dart';
+import 'package:flutter_app/widgets/menu.dart';
+import 'package:flutter_app/widgets/message/item/image/image_preview_page.dart';
+import 'package:flutter_app/widgets/message/item/post_message.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
+
+class _TestDatabaseOpener extends DatabaseOpener {
+  _TestDatabaseOpener(Database database) {
+    state = AsyncValue.data(database);
+  }
+}
+
+void main() {
+  setUpAll(EventBus.initialize);
+
+  testWidgets('Escape closes the image preview route', (tester) async {
+    final database = Database(
+      MixinDatabase(NativeDatabase.memory()),
+      FtsDatabase(NativeDatabase.memory()),
+    );
+    addTearDown(database.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          databaseProvider.overrideWith(
+            (ref) => _TestDatabaseOpener(database),
+          ),
+        ],
+        child: BrightnessData(
+          value: 0,
+          brightnessThemeData: lightBrightnessThemeData,
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: TextButton(
+                  onPressed: () {
+                    showGeneralDialog(
+                      context: context,
+                      barrierColor: Colors.transparent,
+                      barrierLabel: MaterialLocalizations.of(
+                        context,
+                      ).modalBarrierDismissLabel,
+                      pageBuilder: (_, _, _) => const ImagePreviewPage(
+                        conversationId: 'conversation',
+                        messageId: 'message',
+                        isTranscriptPage: false,
+                      ),
+                    );
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pump();
+    expect(find.byType(ImagePreviewPage), findsOneWidget);
+    expect(find.byType(CustomContextMenuWidget), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ImagePreviewPage), findsNothing);
+  });
+
+  testWidgets('Escape closes the post preview route', (tester) async {
+    final message = MessageItem(
+      messageId: 'post',
+      conversationId: 'conversation',
+      type: MessageCategory.plainPost,
+      content: 'post',
+      createdAt: DateTime(2026),
+      status: MessageStatus.read,
+      userId: 'user',
+      userIdentityNumber: '0',
+      isVerified: false,
+      sharedUserIsVerified: false,
+      pinned: false,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingProvider.overrideWith((ref) => SettingChangeNotifier()),
+        ],
+        child: BrightnessData(
+          value: 0,
+          brightnessThemeData: lightBrightnessThemeData,
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: TextButton(
+                  onPressed: () {
+                    showGeneralDialog(
+                      context: context,
+                      barrierColor: Colors.transparent,
+                      barrierLabel: MaterialLocalizations.of(
+                        context,
+                      ).modalBarrierDismissLabel,
+                      pageBuilder: (_, _, _) => PostPreview(message: message),
+                    );
+                  },
+                  child: const Text('open post'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open post'));
+    await tester.pump();
+    expect(find.byType(PostPreview), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PostPreview), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

- Restore explicit Escape dismissal for image and post previews.
- Restore the desktop context menu for image previews while preserving pinned-page actions.
- Add widget coverage for both preview routes.

## Validation

- Targeted Flutter analyze passed.
- Image preview widget tests passed.