### PR TITLE
fix: preserve quote target at unread boundary

### DIFF
--- a/lib/ui/home/chat/chat_timeline_window.dart
+++ b/lib/ui/home/chat/chat_timeline_window.dart
@@ -6,6 +6,7 @@ import 'chat_scroll_coordinator.dart';
 class ChatTimelineWindow {
   ChatTimelineWindow(this.state)
     : anchorUnreadSeparator =
+          state.anchor is UnreadMessageWindowAnchor &&
           state.center != null &&
           state.center!.messageId == state.lastReadMessageId &&
           state.bottom.isNotEmpty {

--- a/test/ui/home/chat/chat_timeline_window_test.dart
+++ b/test/ui/home/chat/chat_timeline_window_test.dart
@@ -15,6 +15,9 @@ void main() {
         center: center,
         bottom: [testMessage(11)],
         lastReadMessageId: center.messageId,
+        anchor: UnreadMessageWindowAnchor(
+          lastReadMessageId: center.messageId,
+        ),
       ),
     );
 
@@ -39,6 +42,27 @@ void main() {
 
     expect(window.anchorUnreadSeparator, false);
     expect(window.scrollAnchor, ChatScrollCoordinator.messageFocusAnchor);
+    expect(window.restoreCenterMessageId, center.messageId);
+    expect(window.rows.center?.message.messageId, center.messageId);
+  });
+
+  test('around anchor keeps a last-read target as the center message', () {
+    final center = testMessage(10);
+    final window = ChatTimelineWindow(
+      MessageState(
+        conversationId: 'conversation',
+        top: [testMessage(1)],
+        center: center,
+        bottom: [testMessage(11)],
+        lastReadMessageId: center.messageId,
+        anchor: AroundMessageWindowAnchor(
+          messageId: center.messageId,
+          source: MessageWindowJumpSource.message,
+        ),
+      ),
+    );
+
+    expect(window.anchorUnreadSeparator, false);
     expect(window.restoreCenterMessageId, center.messageId);
     expect(window.rows.center?.message.messageId, center.messageId);
   });


### PR DESCRIPTION
## Summary

- Keep the unread separator anchor exclusive to unread-window restores.
- Preserve an around-message restore when the quote target is the last-read message.

## Validation

- `flutter test test/ui/home/chat/chat_timeline_window_test.dart test/ui/home/chat/chat_scroll_coordinator_test.dart`
- `flutter analyze lib/ui/home/chat/chat_timeline_window.dart test/ui/home/chat/chat_timeline_window_test.dart`