### PR TITLE
fix: align quit conversation handling

### DIFF
--- a/lib/db/dao/conversation_dao.dart
+++ b/lib/db/dao/conversation_dao.dart
@@ -113,10 +113,6 @@ class ConversationDao extends DatabaseAccessor<MixinDatabase>
     return predicate;
   }
 
-  Expression<bool> _sendableConversationPredicate(Conversations conversation) =>
-      conversation.category.equalsValue(ConversationCategory.group).not() |
-      conversation.status.equalsValue(ConversationStatus.quit).not();
-
   Future<int> conversationCountByCategory(SlideCategoryType category) =>
       _baseConversationItemCount(
         (conversation, owner, circle) =>
@@ -505,18 +501,16 @@ class ConversationDao extends DatabaseAccessor<MixinDatabase>
       return _fuzzySearchConversationInCircle(
         query.trim().escapeSql(),
         category!.id,
-        (conversation, owner, message, _, cc, _) =>
-            _sendableConversationPredicate(conversation) &
-            (filterUnseen
-                ? conversation.unseenMessageCount.isBiggerThanValue(0)
-                : ignoreWhere),
+        (conversation, owner, message, _, cc, _) => filterUnseen
+            ? conversation.unseenMessageCount.isBiggerThanValue(0)
+            : ignoreWhere,
         (conversation, owner, message, _, cc, _) => Limit(limit, null),
       );
     }
     return _fuzzySearchConversation(
       query.trim().escapeSql(),
       (conversation, owner, message, _, _) {
-        var predicate = _sendableConversationPredicate(conversation);
+        Expression<bool> predicate = ignoreWhere;
         switch (category?.type) {
           case SlideCategoryType.contacts:
           case SlideCategoryType.groups:
@@ -565,24 +559,16 @@ class ConversationDao extends DatabaseAccessor<MixinDatabase>
       db.fuzzySearchConversationItem(
         keyword.trim(),
         (conversation, user) =>
-            _sendableConversationPredicate(conversation) &
-            ((conversation.category.equalsValue(ConversationCategory.group))
-                //
-                |
-                //
-                (conversation.category.equalsValue(
-                      ConversationCategory.contact,
-                    ) &
-                    user.relationship.equalsValue(UserRelationship.stranger))),
+            conversation.category.equalsValue(ConversationCategory.group) |
+            (conversation.category.equalsValue(ConversationCategory.contact) &
+                user.relationship.equalsValue(UserRelationship.stranger)),
         (conversation, user) => maxLimit,
       );
 
   Selectable<SearchItem> fuzzySearchConversationItemByIds(List<String> ids) =>
       db.fuzzySearchConversationItem(
         '',
-        (conversation, user) =>
-            _sendableConversationPredicate(conversation) &
-            conversation.conversationId.isIn(ids),
+        (conversation, user) => conversation.conversationId.isIn(ids),
         (conversation, user) => maxLimit,
       );
 

--- a/lib/ui/home/chat_slide_page/chat_info_page.dart
+++ b/lib/ui/home/chat_slide_page/chat_info_page.dart
@@ -79,17 +79,19 @@ class ChatInfoPage extends HookConsumerWidget {
 
     final isGroupConversation = conversationState.isGroup ?? false;
     final muting = conversationState.conversation?.isMute == true;
+    final isExited =
+        userParticipant == null ||
+        conversationState.conversation?.status == ConversationStatus.quit;
     final isOwnerOrAdmin =
-        userParticipant?.role == ParticipantRole.owner ||
-        userParticipant?.role == ParticipantRole.admin;
+        !isExited &&
+        (userParticipant.role == ParticipantRole.owner ||
+            userParticipant.role == ParticipantRole.admin);
 
     final expireIn =
         conversationState.conversation?.expireDuration ?? Duration.zero;
 
     final canModifyExpireIn =
         !isGroupConversation || (isGroupConversation && isOwnerOrAdmin);
-
-    final isExited = userParticipant == null;
     return Scaffold(
       appBar: MixinAppBar(
         actions: [

--- a/lib/ui/home/chat_slide_page/group_participants_page.dart
+++ b/lib/ui/home/chat_slide_page/group_participants_page.dart
@@ -68,7 +68,7 @@ class GroupParticipantsPage extends HookConsumerWidget {
       appBar: MixinAppBar(
         title: Text(context.l10n.groupParticipants),
         actions: [
-          if (currentUser?.role != null)
+          if (hasParticipant && currentUser?.role != null)
             _ActionAddParticipants(participants: participants),
         ],
       ),

--- a/lib/ui/home/notifier/conversation_list_controller.dart
+++ b/lib/ui/home/notifier/conversation_list_controller.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_app_icon_badge/flutter_app_icon_badge.dart';
 import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart'
-    show ConversationCategory, ConversationStatus;
+    show ConversationCategory;
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import '../../../core/conversation/conversation_list_store.dart';
@@ -88,9 +88,7 @@ class ConversationListController extends ValueNotifier<ConversationListState> {
     final matches =
         state.items.where((item) {
           final name = item.isGroupConversation ? item.groupName : item.name;
-          return (item.isGroupConversation &&
-                      item.status != ConversationStatus.quit ||
-                  item.isStrangerConversation) &&
+          return (item.isGroupConversation || item.isStrangerConversation) &&
               name?.toLowerCase().contains(normalizedQuery) == true &&
               (!filterUnseen || (item.unseenMessageCount ?? 0) > 0);
         }).toList()..sort((a, b) {

--- a/lib/widgets/user_selector/conversation_filter_notifier.dart
+++ b/lib/widgets/user_selector/conversation_filter_notifier.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart'
+    show ConversationStatus;
 
 import '../../account/account_server.dart';
 import '../../db/dao/conversation_dao.dart';
@@ -14,8 +16,9 @@ class ConversationFilterNotifier
     this.accountServer,
     this.onlyContact,
     this.filteredIds,
-    this.afterInit,
-  ) : super(const ConversationFilterState()) {
+    this.afterInit, {
+    this.selectedConversationIds = const [],
+  }) : super(const ConversationFilterState()) {
     unawaited(_init());
   }
 
@@ -23,6 +26,7 @@ class ConversationFilterNotifier
   final bool onlyContact;
   final Function(ConversationFilterState) afterInit;
   final Iterable<String> filteredIds;
+  final Iterable<String> selectedConversationIds;
 
   var _conversations = <ConversationItem>[];
   var _friends = <User>[];
@@ -35,9 +39,26 @@ class ConversationFilterNotifier
     if (onlyContact) {
       _conversations = [];
     } else {
-      _conversations = await accountServer.database.conversationDao
-          .conversationItems()
-          .get();
+      _conversations =
+          (await accountServer.database.conversationDao
+                  .conversationItems()
+                  .get())
+              .where(
+                (conversation) =>
+                    !conversation.isGroupConversation ||
+                    conversation.status != ConversationStatus.quit,
+              )
+              .toList();
+      final conversationIds = _conversations
+          .map((conversation) => conversation.conversationId)
+          .toSet();
+      _conversations.addAll(
+        (await accountServer.database.conversationDao.conversationItemsByIds(
+          selectedConversationIds,
+        )).where(
+          (conversation) => conversationIds.add(conversation.conversationId),
+        ),
+      );
       contactConversationIds = _conversations
           .where(
             (element) =>
@@ -55,7 +76,6 @@ class ConversationFilterNotifier
 
     _friends = <User>[];
     _bots = <User>[];
-
     final Iterable<User> users = await accountServer.database.userDao
         .notInFriends([
           ...contactConversationIds,

--- a/lib/widgets/user_selector/conversation_selector.dart
+++ b/lib/widgets/user_selector/conversation_selector.dart
@@ -207,8 +207,9 @@ class _ConversationSelector extends HookConsumerWidget {
             selectItem(element);
           });
         },
+        selectedConversationIds: initSelected.map((e) => e.conversationId),
       ),
-      [accountServer, onlyContact, filteredIds],
+      [accountServer, onlyContact, filteredIds, initSelected],
     );
     useEffect(
       () => conversationFilterNotifier.dispose,

--- a/test/db/conversation_dao_test.dart
+++ b/test/db/conversation_dao_test.dart
@@ -8,7 +8,7 @@ import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart'
     show ConversationCategory, ConversationStatus, UserRelationship;
 
 void main() {
-  test('conversation searches exclude quit groups but keep contacts', () async {
+  test('conversation searches include quit groups', () async {
     final database = MixinDatabase(NativeDatabase.memory());
     addTearDown(database.close);
 
@@ -67,7 +67,7 @@ void main() {
         .get();
     expect(
       typedPaletteResults.map((item) => item.id).toSet(),
-      {'active-group', 'quit-contact'},
+      {'active-group', 'quit-group', 'quit-contact'},
     );
 
     final recentPaletteResults = await database.conversationDao
@@ -79,7 +79,7 @@ void main() {
         .get();
     expect(
       recentPaletteResults.map((item) => item.id).toSet(),
-      {'active-group', 'quit-contact'},
+      {'active-group', 'quit-group', 'quit-contact'},
     );
 
     final quitContactResults = await database.conversationDao
@@ -87,15 +87,15 @@ void main() {
         .get();
     expect(
       quitContactResults.map((item) => item.id).toSet(),
-      {'active-group', 'quit-contact'},
+      {'active-group', 'quit-group', 'quit-contact'},
     );
 
     final regularSearchResults = await database.conversationDao
         .fuzzySearchConversation('Group', 32)
         .get();
     expect(
-      regularSearchResults.map((item) => item.conversationId),
-      ['active-group'],
+      regularSearchResults.map((item) => item.conversationId).toSet(),
+      {'active-group', 'quit-group'},
     );
 
     final regularQuitContactResults = await database.conversationDao
@@ -103,7 +103,7 @@ void main() {
         .get();
     expect(
       regularQuitContactResults.map((item) => item.conversationId).toSet(),
-      {'active-group', 'quit-contact'},
+      {'quit-contact'},
     );
   });
 }

--- a/test/ui/home/notifier/conversation_list_controller_test.dart
+++ b/test/ui/home/notifier/conversation_list_controller_test.dart
@@ -72,6 +72,11 @@ void main() {
             identityNumber: '3',
             fullName: 'Group owner',
           ),
+          const User(
+            userId: 'quit-group-owner',
+            identityNumber: '4',
+            fullName: 'Quit group owner',
+          ),
         ])
         ..insertAll(mixinDatabase.conversations, [
           Conversation(
@@ -96,6 +101,14 @@ void main() {
             createdAt: now,
             status: ConversationStatus.success,
           ),
+          Conversation(
+            conversationId: 'quit-group-chat',
+            ownerId: 'quit-group-owner',
+            category: ConversationCategory.group,
+            name: '主退出群',
+            createdAt: now.subtract(const Duration(minutes: 1)),
+            status: ConversationStatus.quit,
+          ),
         ])
         ..insert(
           mixinDatabase.circleConversations,
@@ -113,14 +126,13 @@ void main() {
     final initialized = controller.addListenerCompleter();
     await store.start();
     await initialized.future;
-    expect(controller.state.count, 3);
+    expect(controller.state.count, 4);
     expect(
       controller
           .search('主', filterUnseen: false)!
-          .map(
-            (item) => item.conversationId,
-          ),
-      ['group-chat', 'stranger-chat'],
+          .map((item) => item.conversationId)
+          .toSet(),
+      {'group-chat', 'quit-group-chat', 'stranger-chat'},
     );
 
     final contactsChanged = controller.addListenerCompleter();
@@ -162,7 +174,7 @@ void main() {
     await changed.future;
     expect(
       controller.state.items.map((item) => item.conversationId),
-      ['group-chat', 'friend-chat', 'stranger-chat'],
+      ['group-chat', 'friend-chat', 'stranger-chat', 'quit-group-chat'],
     );
   });
 }

--- a/test/widgets/conversation_filter_notifier_test.dart
+++ b/test/widgets/conversation_filter_notifier_test.dart
@@ -1,0 +1,131 @@
+@TestOn('linux || mac-os')
+library;
+
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter_app/account/account_server.dart';
+import 'package:flutter_app/db/database.dart';
+import 'package:flutter_app/db/fts_database.dart';
+import 'package:flutter_app/db/mixin_database.dart';
+import 'package:flutter_app/ui/provider/multi_auth_provider.dart';
+import 'package:flutter_app/ui/provider/setting_provider.dart';
+import 'package:flutter_app/widgets/user_selector/conversation_filter_notifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart'
+    show ConversationCategory, ConversationStatus, UserRelationship;
+
+void main() {
+  test('filters quit groups unless selected', () async {
+    final database = Database(
+      MixinDatabase(NativeDatabase.memory()),
+      FtsDatabase(NativeDatabase.memory()),
+    );
+    addTearDown(database.dispose);
+
+    final now = DateTime(2026);
+    await database.mixinDatabase.batch((batch) {
+      batch
+        ..insertAll(database.mixinDatabase.users, [
+          const User(
+            userId: 'active-owner',
+            identityNumber: '7001',
+            fullName: 'Active Group Owner',
+            relationship: UserRelationship.friend,
+          ),
+          const User(
+            userId: 'quit-owner',
+            identityNumber: '7002',
+            fullName: 'Quit Group Owner',
+            relationship: UserRelationship.friend,
+          ),
+          const User(
+            userId: 'quit-contact-owner',
+            identityNumber: '7003',
+            fullName: 'Quit Contact Owner',
+            relationship: UserRelationship.friend,
+          ),
+          const User(
+            userId: 'other-quit-owner',
+            identityNumber: '7004',
+            fullName: 'Other Quit Group Owner',
+            relationship: UserRelationship.friend,
+          ),
+        ])
+        ..insertAll(database.mixinDatabase.conversations, [
+          Conversation(
+            conversationId: 'active-group',
+            ownerId: 'active-owner',
+            category: ConversationCategory.group,
+            name: 'Active Group',
+            createdAt: now,
+            status: ConversationStatus.success,
+          ),
+          Conversation(
+            conversationId: 'quit-group',
+            ownerId: 'quit-owner',
+            category: ConversationCategory.group,
+            name: 'Quit Group',
+            createdAt: now,
+            status: ConversationStatus.quit,
+          ),
+          Conversation(
+            conversationId: 'other-quit-group',
+            ownerId: 'other-quit-owner',
+            category: ConversationCategory.group,
+            name: 'Other Quit Group',
+            createdAt: now,
+            status: ConversationStatus.quit,
+          ),
+          Conversation(
+            conversationId: 'quit-contact',
+            ownerId: 'quit-contact-owner',
+            category: ConversationCategory.contact,
+            name: 'Quit Contact',
+            createdAt: now,
+            status: ConversationStatus.quit,
+          ),
+        ]);
+    });
+
+    final accountServer = AccountServer(
+      multiAuthNotifier: MultiAuthStateNotifier(const MultiAuthState()),
+      settingChangeNotifier: SettingChangeNotifier(),
+      database: database,
+      currentConversationId: () => null,
+    );
+    final initialized = Completer<ConversationFilterState>();
+    final notifier = ConversationFilterNotifier(
+      accountServer,
+      false,
+      const [],
+      initialized.complete,
+    );
+    addTearDown(notifier.dispose);
+
+    final state = await initialized.future;
+
+    final ids = state.recentConversations
+        .map((item) => item.conversationId)
+        .toList();
+    expect(ids, contains('active-group'));
+    expect(ids, contains('quit-contact'));
+    expect(ids, isNot(contains('quit-group')));
+    expect(ids, isNot(contains('other-quit-group')));
+
+    final selectedInitialized = Completer<ConversationFilterState>();
+    final selectedNotifier = ConversationFilterNotifier(
+      accountServer,
+      false,
+      const [],
+      selectedInitialized.complete,
+      selectedConversationIds: const ['quit-group'],
+    );
+    addTearDown(selectedNotifier.dispose);
+
+    final selectedIds = (await selectedInitialized.future).recentConversations
+        .map((item) => item.conversationId);
+    expect(selectedIds, contains('quit-group'));
+    expect(selectedIds, isNot(contains('other-quit-group')));
+  });
+}


### PR DESCRIPTION
## Summary

- Exclude exited groups from conversation recipient selectors while preserving explicitly selected Circle members.
- Retain exited conversations in history and conversation search.
- Hide group management actions when the conversation status is QUIT, even if participant data is stale.

## Validation

- `flutter test test/db/conversation_dao_test.dart test/ui/home/notifier/conversation_list_controller_test.dart test/widgets/conversation_filter_notifier_test.dart`
- `flutter analyze` on the changed Dart files.