### PR TITLE
fix: restore transcript attachment downloads

### DIFF
--- a/lib/account/account_server.dart
+++ b/lib/account/account_server.dart
@@ -127,9 +127,66 @@ class AccountServer {
     unawaited(conversationListStore.start());
     unawaited(_start());
 
-    DownloadKeyValue.instance.messageIds.forEach((messageId) {
-      attachmentUtil.downloadAttachment(messageId: messageId);
-    });
+    for (final jobKey in DownloadKeyValue.instance.messageIds.toList()) {
+      final separator = jobKey.indexOf('|');
+      if (separator == -1) {
+        final message = await database.messageDao.findMessageByMessageId(
+          jobKey,
+        );
+        final transcripts = await database.transcriptMessageDao
+            .transcriptMessageByMessageId(jobKey)
+            .get();
+        if (message != null) {
+          unawaited(attachmentUtil.downloadAttachment(messageId: jobKey));
+        } else if (transcripts.length == 1) {
+          unawaited(
+            attachmentUtil.downloadAttachment(
+              messageId: jobKey,
+              transcriptId: transcripts.single.transcriptId,
+            ),
+          );
+        } else {
+          unawaited(DownloadKeyValue.instance.removeMessageId(jobKey));
+        }
+        continue;
+      }
+      final transcriptId = jobKey.substring(0, separator);
+      final messageId = jobKey.substring(separator + 1);
+      final transcriptMessage = await database.transcriptMessageDao
+          .transcriptMessageByIds(transcriptId, messageId)
+          .getSingleOrNull();
+      if (transcriptMessage == null) {
+        await DownloadKeyValue.instance.removeMessageId(jobKey);
+        continue;
+      }
+      unawaited(
+        attachmentUtil.downloadAttachment(
+          messageId: messageId,
+          transcriptId: transcriptId,
+        ),
+      );
+    }
+    final pendingTranscriptMessages = await database.transcriptMessageDao
+        .pendingTranscriptMessages()
+        .get();
+    for (final message in pendingTranscriptMessages) {
+      if (!message.category.isAttachment) continue;
+      final parent = await database.messageDao.findMessageByMessageId(
+        message.transcriptId,
+      );
+      if (parent == null ||
+          parent.userId == userId ||
+          parent.status == MessageStatus.sending) {
+        continue;
+      }
+      unawaited(
+        attachmentUtil.downloadAttachment(
+          messageId: message.messageId,
+          transcriptId: message.transcriptId,
+        ),
+      );
+    }
+
     appActiveListener.addListener(onActive);
   }
 
@@ -342,16 +399,23 @@ class AccountServer {
         'request download transcript: ${request.message.messageId} ${request.message.category}',
       );
       final messageId = request.message.messageId;
+      final transcriptId = request.message.transcriptId;
       if (needDownload(request.message.category)) {
         await attachmentUtil.downloadAttachment(
-          messageId: request.message.messageId,
+          messageId: messageId,
+          transcriptId: transcriptId,
         );
       } else {
-        await attachmentUtil.checkSyncMessageMedia(messageId);
+        await attachmentUtil.checkSyncMessageMedia(
+          messageId,
+          transcriptId: transcriptId,
+        );
       }
     } else if (request is AttachmentDeleteRequest) {
       try {
-        await attachmentUtil.removeAttachmentJob(request.message.messageId);
+        await attachmentUtil.removeAttachmentJobsByParentId(
+          request.message.messageId,
+        );
         await _deleteMessageAttachment(request.message);
         request.resultPort?.send(null);
       } catch (error) {
@@ -997,8 +1061,13 @@ class AccountServer {
     }
   }
 
-  Future<void> downloadAttachment(String messageId) async =>
-      attachmentUtil.downloadAttachment(messageId: messageId);
+  Future<void> downloadAttachment(
+    String messageId, {
+    String? transcriptId,
+  }) async => attachmentUtil.downloadAttachment(
+    messageId: messageId,
+    transcriptId: transcriptId,
+  );
 
   Future<void> reUploadGiphyGif(db.MessageItem message) {
     assert(
@@ -1430,8 +1499,13 @@ class AccountServer {
     multiAuthNotifier.updateAccount(user.data);
   }
 
-  Future<bool> cancelProgressAttachmentJob(String messageId) =>
-      attachmentUtil.cancelProgressAttachmentJob(messageId);
+  Future<bool> cancelProgressAttachmentJob(
+    String messageId, {
+    String? transcriptId,
+  }) => attachmentUtil.cancelProgressAttachmentJob(
+    messageId,
+    transcriptId: transcriptId,
+  );
 
   Future<void> _deleteMessageAttachment(db.Message message) async {
     if (message.category.isAttachment) {
@@ -1487,7 +1561,7 @@ class AccountServer {
   Future<void> deleteMessage(String messageId) async {
     final message = await database.messageDao.findMessageByMessageId(messageId);
     if (message == null) return;
-    await attachmentUtil.cancelProgressAttachmentJob(messageId);
+    await attachmentUtil.removeAttachmentJobsByParentId(messageId);
     await database.messageDao.deleteMessage(message.conversationId, messageId);
     unawaited(database.ftsDatabase.deleteByMessageId(messageId));
     unawaited(_deleteMessageAttachment(message));
@@ -1495,14 +1569,14 @@ class AccountServer {
 
   Future<void> deleteMessagesByConversationId(String conversationId) async {
     final miniMessageIds = await database.messageDao
-        .miniMessageByIds(attachmentUtil.downloadingIds.toList())
+        .miniMessageByIds(attachmentUtil.downloadingParentIds.toList())
         .get();
     await Future.forEach(
       miniMessageIds.where(
         (message) => message.conversationId == conversationId,
       ),
       (message) =>
-          attachmentUtil.cancelProgressAttachmentJob(message.messageId),
+          attachmentUtil.removeAttachmentJobsByParentId(message.messageId),
     );
 
     await database.messageDao.deleteMessagesByConversationId(conversationId);

--- a/lib/db/dao/message_dao.dart
+++ b/lib/db/dao/message_dao.dart
@@ -431,30 +431,43 @@ class MessageDao extends DatabaseAccessor<MixinDatabase>
     required int mediaSize,
     required MediaStatus mediaStatus,
     String? content,
+    String? transcriptId,
   }) async {
-    final [messageResult, transcriptMessageResult] = await db.transaction(
-      () => Future.wait([
-        (db.update(
-          db.messages,
-        )..where((tbl) => tbl.messageId.equals(messageId))).write(
-          MessagesCompanion(
-            mediaUrl: Value(path.pathBasename),
-            mediaSize: Value(mediaSize),
-            mediaStatus: Value(mediaStatus),
-          ),
+    var messageResult = 0;
+    var transcriptMessageResult = 0;
+    await db.transaction(() async {
+      if (transcriptId == null) {
+        messageResult =
+            await (db.update(
+              db.messages,
+            )..where((tbl) => tbl.messageId.equals(messageId))).write(
+              MessagesCompanion(
+                mediaUrl: Value(path.pathBasename),
+                mediaSize: Value(mediaSize),
+                mediaStatus: Value(mediaStatus),
+              ),
+            );
+      }
+
+      final update = db.update(db.transcriptMessages);
+      if (transcriptId == null) {
+        update.where((tbl) => tbl.messageId.equals(messageId));
+      } else {
+        update.where(
+          (tbl) =>
+              tbl.transcriptId.equals(transcriptId) &
+              tbl.messageId.equals(messageId),
+        );
+      }
+      transcriptMessageResult = await update.write(
+        TranscriptMessagesCompanion(
+          mediaUrl: Value(path.pathBasename),
+          mediaSize: Value(mediaSize),
+          mediaStatus: Value(mediaStatus),
+          content: content != null ? Value(content) : const Value.absent(),
         ),
-        (db.update(
-          db.transcriptMessages,
-        )..where((tbl) => tbl.messageId.equals(messageId))).write(
-          TranscriptMessagesCompanion(
-            mediaUrl: Value(path.pathBasename),
-            mediaSize: Value(mediaSize),
-            mediaStatus: Value(mediaStatus),
-            content: content != null ? Value(content) : const Value.absent(),
-          ),
-        ),
-      ]),
-    );
+      );
+    });
 
     await _notifyEventByMessageId(
       messageId,
@@ -463,21 +476,46 @@ class MessageDao extends DatabaseAccessor<MixinDatabase>
     );
   }
 
-  Future<void> updateMediaStatus(String messageId, MediaStatus status) async {
-    if (!await hasMediaStatus(messageId, status, true)) return;
+  Future<void> updateMediaStatus(
+    String messageId,
+    MediaStatus status, {
+    String? transcriptId,
+  }) async {
+    final hasStatus = transcriptId == null
+        ? await hasMediaStatus(messageId, status, true)
+        : await transcriptMessageHasMediaStatusById(
+            transcriptId,
+            messageId,
+            status,
+            true,
+          );
+    if (!hasStatus) return;
 
-    final [messageResult, transcriptMessageResult] = await db.transaction(
-      () => Future.wait([
-        (db.update(db.messages)..where(
-              (tbl) => tbl.messageId.equals(messageId),
-            ))
-            .write(MessagesCompanion(mediaStatus: Value(status))),
-        (db.update(db.transcriptMessages)..where(
-              (tbl) => tbl.messageId.equals(messageId),
-            ))
-            .write(TranscriptMessagesCompanion(mediaStatus: Value(status))),
-      ]),
-    );
+    var messageResult = 0;
+    var transcriptMessageResult = 0;
+    await db.transaction(() async {
+      if (transcriptId == null) {
+        messageResult =
+            await (db.update(db.messages)..where(
+                  (tbl) => tbl.messageId.equals(messageId),
+                ))
+                .write(MessagesCompanion(mediaStatus: Value(status)));
+      }
+
+      final update = db.update(db.transcriptMessages);
+      if (transcriptId == null) {
+        update.where((tbl) => tbl.messageId.equals(messageId));
+      } else {
+        update.where(
+          (tbl) =>
+              tbl.transcriptId.equals(transcriptId) &
+              tbl.messageId.equals(messageId),
+        );
+      }
+      transcriptMessageResult = await update.write(
+        TranscriptMessagesCompanion(mediaStatus: Value(status)),
+      );
+    });
 
     await _notifyEventByMessageId(
       messageId,
@@ -557,6 +595,25 @@ class MessageDao extends DatabaseAccessor<MixinDatabase>
     final predicate = not
         ? equalsId & equalsStatus.not()
         : equalsId & equalsStatus;
+    return db.hasData(db.transcriptMessages, [], predicate);
+  }
+
+  Future<bool> transcriptMessageHasMediaStatusById(
+    String transcriptId,
+    String messageId,
+    MediaStatus mediaStatus, [
+    bool not = false,
+  ]) async {
+    final equalsTranscript = db.transcriptMessages.transcriptId.equals(
+      transcriptId,
+    );
+    final equalsId = db.transcriptMessages.messageId.equals(messageId);
+    final equalsStatus = db.transcriptMessages.mediaStatus.equalsValue(
+      mediaStatus,
+    );
+    final predicate =
+        equalsTranscript &
+        (not ? equalsId & equalsStatus.not() : equalsId & equalsStatus);
     return db.hasData(db.transcriptMessages, [], predicate);
   }
 

--- a/lib/db/dao/transcript_message_dao.dart
+++ b/lib/db/dao/transcript_message_dao.dart
@@ -47,6 +47,19 @@ class TranscriptMessageDao extends DatabaseAccessor<MixinDatabase>
         ..where((tbl) => tbl.messageId.equals(messageId))
         // ignore: invalid_use_of_protected_member
         ..limitExpr = limit ?? Limit(1, 0));
+  Selectable<TranscriptMessage> transcriptMessageByIds(
+    String transcriptId,
+    String messageId,
+  ) => (db.select(db.transcriptMessages)
+    ..where(
+      (tbl) =>
+          tbl.transcriptId.equals(transcriptId) &
+          tbl.messageId.equals(messageId),
+    ));
+  SimpleSelectStatement<TranscriptMessages, TranscriptMessage>
+  pendingTranscriptMessages() =>
+      db.select(db.transcriptMessages)
+        ..where((tbl) => tbl.mediaStatus.equalsValue(MediaStatus.pending));
 
   SimpleSelectStatement<TranscriptMessages, TranscriptMessage>
   transcriptMessageByTranscriptId(String transcriptId) =>

--- a/lib/utils/attachment/attachment_util.dart
+++ b/lib/utils/attachment/attachment_util.dart
@@ -670,8 +670,8 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
       transcriptId: transcriptId,
     );
     final hasJob = _hasAttachmentJob(messageId, transcriptId: transcriptId);
-    _attachmentDownloadKeys[_attachmentJobKey(messageId, transcriptId)]
-        ?.invalidated = true;
+    final key = _attachmentJobKey(messageId, transcriptId);
+    _attachmentDownloadKeys[key]?.invalidated = true;
     await removeAttachmentJob(messageId, transcriptId: transcriptId);
     if (!hasJob) {
       w('cancelProgressAttachmentJob: no job for $messageId');

--- a/lib/utils/attachment/attachment_util.dart
+++ b/lib/utils/attachment/attachment_util.dart
@@ -75,6 +75,10 @@ abstract class _AttachmentJobBase {
   }
 }
 
+class _AttachmentDownloadReservation {
+  bool invalidated = false;
+}
+
 class AttachmentUtilBase {
   AttachmentUtilBase(this.mediaPath)
     : transcriptPath = p.join(mediaPath, 'Transcripts') {
@@ -171,7 +175,7 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
   final SettingPropertyStorage _settingProperties;
 
   final _attachmentJob = <String, _AttachmentJobBase>{};
-  final _attachmentDownloadKeys = <String>{};
+  final _attachmentDownloadKeys = <String, _AttachmentDownloadReservation>{};
   String _attachmentJobKey(String messageId, String? transcriptId) =>
       transcriptId == null ? messageId : '$transcriptId|$messageId';
 
@@ -215,19 +219,25 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
     String? transcriptId,
   }) async {
     final key = _attachmentJobKey(messageId, transcriptId);
-    if (!_attachmentDownloadKeys.add(key)) return;
+    if (_attachmentDownloadKeys.containsKey(key)) return;
+    final token = _AttachmentDownloadReservation();
+    _attachmentDownloadKeys[key] = token;
     try {
       await _downloadAttachment(
         messageId: messageId,
         transcriptId: transcriptId,
+        reservation: token,
       );
     } finally {
-      _attachmentDownloadKeys.remove(key);
+      if (identical(_attachmentDownloadKeys[key], token)) {
+        _attachmentDownloadKeys.remove(key);
+      }
     }
   }
 
   Future<void> _downloadAttachment({
     required String messageId,
+    required _AttachmentDownloadReservation reservation,
     String? transcriptId,
   }) async {
     if (_hasAttachmentJob(messageId, transcriptId: transcriptId)) return;
@@ -382,6 +392,12 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
               : null,
         );
 
+        final currentReservation =
+            _attachmentDownloadKeys[_attachmentJobKey(messageId, transcriptId)];
+        if (!identical(currentReservation, reservation) ||
+            reservation.invalidated) {
+          return;
+        }
 
         _setAttachmentJob(
           messageId,
@@ -601,18 +617,19 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
   Iterable<String> get downloadingParentIds => {
     ..._attachmentJob.keys,
     ...DownloadKeyValue.instance.messageIds,
-    ..._attachmentDownloadKeys,
+    ..._attachmentDownloadKeys.keys,
   }.map(_parentIdFromAttachmentJobKey).toSet();
 
   Future<void> removeAttachmentJobsByParentId(String parentId) async {
     final keys = {
       ..._attachmentJob.keys,
       ...DownloadKeyValue.instance.messageIds,
-      ..._attachmentDownloadKeys,
+      ..._attachmentDownloadKeys.keys,
     };
     final prefix = '$parentId|';
     for (final key in keys) {
       if (key != parentId && !key.startsWith(prefix)) continue;
+      _attachmentDownloadKeys[key]?.invalidated = true;
       final separator = key.indexOf('|');
       await removeAttachmentJob(
         separator == -1 ? key : key.substring(separator + 1),
@@ -653,6 +670,8 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
       transcriptId: transcriptId,
     );
     final hasJob = _hasAttachmentJob(messageId, transcriptId: transcriptId);
+    _attachmentDownloadKeys[_attachmentJobKey(messageId, transcriptId)]
+        ?.invalidated = true;
     await removeAttachmentJob(messageId, transcriptId: transcriptId);
     if (!hasJob) {
       w('cancelProgressAttachmentJob: no job for $messageId');

--- a/lib/utils/attachment/attachment_util.dart
+++ b/lib/utils/attachment/attachment_util.dart
@@ -171,9 +171,30 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
   final SettingPropertyStorage _settingProperties;
 
   final _attachmentJob = <String, _AttachmentJobBase>{};
+  final _attachmentDownloadKeys = <String>{};
+  String _attachmentJobKey(String messageId, String? transcriptId) =>
+      transcriptId == null ? messageId : '$transcriptId|$messageId';
+
+  String _parentIdFromAttachmentJobKey(String key) {
+    final separator = key.indexOf('|');
+    return separator == -1 ? key : key.substring(0, separator);
+  }
 
   /// check if the attachment is downloaded, if not, return false, otherwise sync it and  return true
-  Future<bool> checkSyncMessageMedia(String messageId) async {
+  Future<bool> checkSyncMessageMedia(
+    String messageId, {
+    String? transcriptId,
+  }) async {
+    if (transcriptId != null) {
+      if (_hasAttachmentJob(messageId, transcriptId: transcriptId)) {
+        return false;
+      }
+      final transcriptMessage = await _transcriptMessageDao
+          .transcriptMessageByIds(transcriptId, messageId)
+          .getSingleOrNull();
+      return transcriptMessage?.mediaStatus == MediaStatus.done;
+    }
+
     Future<bool> checkDownloaded() async =>
         await _messageDao.messageHasMediaStatus(messageId, MediaStatus.done) ||
         await _messageDao.transcriptMessageHasMediaStatus(
@@ -189,29 +210,63 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
     return false;
   }
 
-  Future<void> downloadAttachment({required String messageId}) async {
-    if (await checkSyncMessageMedia(messageId)) return;
+  Future<void> downloadAttachment({
+    required String messageId,
+    String? transcriptId,
+  }) async {
+    final key = _attachmentJobKey(messageId, transcriptId);
+    if (!_attachmentDownloadKeys.add(key)) return;
+    try {
+      await _downloadAttachment(
+        messageId: messageId,
+        transcriptId: transcriptId,
+      );
+    } finally {
+      _attachmentDownloadKeys.remove(key);
+    }
+  }
 
-    await _messageDao.updateMediaStatus(messageId, MediaStatus.pending);
+  Future<void> _downloadAttachment({
+    required String messageId,
+    String? transcriptId,
+  }) async {
+    if (_hasAttachmentJob(messageId, transcriptId: transcriptId)) return;
+
+    if (await checkSyncMessageMedia(messageId, transcriptId: transcriptId)) {
+      return;
+    }
+
+    await _messageDao.updateMediaStatus(
+      messageId,
+      MediaStatus.pending,
+      transcriptId: transcriptId,
+    );
 
     AttachmentMessage? attachmentMessage;
-
-    final list = await Future.wait([
-      _messageDao.findMessageByMessageId(messageId),
-      _transcriptMessageDao
-          .transcriptMessageByMessageId(messageId)
-          .getSingleOrNull(),
-    ]);
-    final message = list.first as Message?;
-    final transcriptMessage = list[1] as TranscriptMessage?;
+    Message? message;
+    TranscriptMessage? transcriptMessage;
+    if (transcriptId == null) {
+      final list = await Future.wait([
+        _messageDao.findMessageByMessageId(messageId),
+        _transcriptMessageDao
+            .transcriptMessageByMessageId(messageId)
+            .getSingleOrNull(),
+      ]);
+      message = list.first as Message?;
+      transcriptMessage = list[1] as TranscriptMessage?;
+    } else {
+      transcriptMessage = await _transcriptMessageDao
+          .transcriptMessageByIds(transcriptId, messageId)
+          .getSingleOrNull();
+    }
 
     if (message != null) {
       attachmentMessage = AttachmentMessage(
         message.mediaKey,
         message.mediaDigest,
-        message.content!,
-        message.mediaMimeType!,
-        message.mediaSize!,
+        message.content ?? '',
+        message.mediaMimeType ?? '',
+        message.mediaSize ?? 0,
         message.name,
         message.mediaWidth,
         message.mediaHeight,
@@ -227,9 +282,9 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
       attachmentMessage = AttachmentMessage(
         transcriptMessage.mediaKey,
         transcriptMessage.mediaDigest,
-        transcriptMessage.content!,
-        transcriptMessage.mediaMimeType!,
-        transcriptMessage.mediaSize!,
+        transcriptMessage.content ?? '',
+        transcriptMessage.mediaMimeType ?? '',
+        transcriptMessage.mediaSize ?? 0,
         transcriptMessage.userFullName,
         transcriptMessage.mediaWidth,
         transcriptMessage.mediaHeight,
@@ -246,7 +301,10 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
     final conversationId = message?.conversationId;
 
     if (category == null || content == null) {
-      await cancelProgressAttachmentJob(messageId);
+      await cancelProgressAttachmentJob(
+        messageId,
+        transcriptId: transcriptId,
+      );
       return;
     }
 
@@ -260,7 +318,7 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
       );
       attachmentId = attachmentExtra.attachmentId;
       shareable = attachmentExtra.shareable;
-    } catch (e) {
+    } catch (_) {
       attachmentId = content;
     }
 
@@ -274,7 +332,7 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
       messageId,
       message?.name ?? transcriptMessage?.mediaName,
       mimeType: mediaMimeType,
-      isTranscript: message == null,
+      isTranscript: transcriptId != null || message == null,
     );
     final path = file.absolute.path;
     if (file.existsSync()) await file.delete();
@@ -283,7 +341,7 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
       final response = await _client.attachmentApi.getAttachment(attachmentId);
       d('download ${response.data.viewUrl}');
 
-      if (await isNotPending(messageId)) return;
+      if (await isNotPending(messageId, transcriptId: transcriptId)) return;
 
       if (response.data.viewUrl != null) {
         String? mediaKey;
@@ -324,7 +382,12 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
               : null,
         );
 
-        _setAttachmentJob(messageId, attachmentDownloadJob);
+
+        _setAttachmentJob(
+          messageId,
+          attachmentDownloadJob,
+          transcriptId: transcriptId,
+        );
 
         await attachmentDownloadJob.download(
           _settingProperties.activatedProxy,
@@ -334,7 +397,7 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
         await normalizeGifFileIfNeeded(file, mediaMimeType);
         final fileSize = await file.length();
 
-        if (attachmentMessage != null) {
+        if (attachmentMessage != null && transcriptId == null) {
           final content = await jsonEncodeWithIsolate(
             AttachmentExtra(
               attachmentId: response.data.attachmentId,
@@ -363,17 +426,25 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
           path: file.path,
           mediaSize: fileSize,
           mediaStatus: MediaStatus.done,
+          transcriptId: transcriptId,
         );
 
         await _updateMessageQuotedContent(messageId, conversationId);
-        await _updateTranscriptMessageStatus(messageId);
+        await _updateTranscriptMessageStatus(
+          messageId,
+          transcriptId: transcriptId,
+        );
       }
     } catch (er) {
       e(er.toString());
       if (file.existsSync()) await file.delete();
-      await _messageDao.updateMediaStatus(messageId, MediaStatus.canceled);
+      await _messageDao.updateMediaStatus(
+        messageId,
+        MediaStatus.canceled,
+        transcriptId: transcriptId,
+      );
     } finally {
-      await removeAttachmentJob(messageId);
+      await removeAttachmentJob(messageId, transcriptId: transcriptId);
     }
   }
 
@@ -383,8 +454,14 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
     String category, {
     String? transcriptId,
   }) async {
-    assert(!_hasAttachmentJob(messageId));
-    await _messageDao.updateMediaStatus(messageId, MediaStatus.pending);
+    assert(
+      !_hasAttachmentJob(messageId, transcriptId: transcriptId),
+    );
+    await _messageDao.updateMediaStatus(
+      messageId,
+      MediaStatus.pending,
+      transcriptId: transcriptId,
+    );
 
     try {
       final response = await _client.attachmentApi.postAttachment();
@@ -406,13 +483,21 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
         iv: iv,
       );
 
-      _setAttachmentJob(messageId, attachmentUploadJob);
+      _setAttachmentJob(
+        messageId,
+        attachmentUploadJob,
+        transcriptId: transcriptId,
+      );
 
       final digest = await attachmentUploadJob.upload(
         _settingProperties.activatedProxy,
         (count, total) => notifyListeners(),
       );
-      await _messageDao.updateMediaStatus(messageId, MediaStatus.done);
+      await _messageDao.updateMediaStatus(
+        messageId,
+        MediaStatus.done,
+        transcriptId: transcriptId,
+      );
       return AttachmentResult(
         response.data.attachmentId,
         category.isSignal || category.isEncrypted
@@ -430,15 +515,30 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
           (context) => context.l10n.errorUploadAttachmentFailed,
         ),
       );
-      await _messageDao.updateMediaStatus(messageId, MediaStatus.canceled);
+      await _messageDao.updateMediaStatus(
+        messageId,
+        MediaStatus.canceled,
+        transcriptId: transcriptId,
+      );
       return null;
     } finally {
-      await removeAttachmentJob(messageId);
+      await removeAttachmentJob(messageId, transcriptId: transcriptId);
     }
   }
 
-  Future<bool> isNotPending(String messageId) =>
-      _messageDao.hasMediaStatus(messageId, MediaStatus.pending, true);
+  Future<bool> isNotPending(
+    String messageId, {
+    String? transcriptId,
+  }) async {
+    if (transcriptId != null) {
+      return !(await _messageDao.transcriptMessageHasMediaStatusById(
+        transcriptId,
+        messageId,
+        MediaStatus.pending,
+      ));
+    }
+    return _messageDao.hasMediaStatus(messageId, MediaStatus.pending, true);
+  }
 
   File getAttachmentFile(
     String category,
@@ -493,39 +593,79 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
     );
   }
 
-  bool _hasAttachmentJob(String messageId) =>
-      _attachmentJob.containsKey(messageId);
+  bool _hasAttachmentJob(
+    String messageId, {
+    String? transcriptId,
+  }) => _attachmentJob.containsKey(_attachmentJobKey(messageId, transcriptId));
 
-  Iterable<String> get downloadingIds =>
-      _attachmentJob.entries.map((e) => e.key);
+  Iterable<String> get downloadingParentIds => {
+    ..._attachmentJob.keys,
+    ...DownloadKeyValue.instance.messageIds,
+    ..._attachmentDownloadKeys,
+  }.map(_parentIdFromAttachmentJobKey).toSet();
 
-  void _setAttachmentJob(String messageId, _AttachmentJobBase job) {
-    _attachmentJob[messageId] = job;
-    if (job is _AttachmentDownloadJob) {
-      DownloadKeyValue.instance.addMessageId(messageId);
+  Future<void> removeAttachmentJobsByParentId(String parentId) async {
+    final keys = {
+      ..._attachmentJob.keys,
+      ...DownloadKeyValue.instance.messageIds,
+      ..._attachmentDownloadKeys,
+    };
+    final prefix = '$parentId|';
+    for (final key in keys) {
+      if (key != parentId && !key.startsWith(prefix)) continue;
+      final separator = key.indexOf('|');
+      await removeAttachmentJob(
+        separator == -1 ? key : key.substring(separator + 1),
+        transcriptId: separator == -1 ? null : key.substring(0, separator),
+      );
     }
   }
 
-  Future<void> removeAttachmentJob(String messageId) async {
-    await DownloadKeyValue.instance.removeMessageId(messageId);
-    _attachmentJob[messageId]?.cancel();
-    _attachmentJob.remove(messageId);
+  void _setAttachmentJob(
+    String messageId,
+    _AttachmentJobBase job, {
+    String? transcriptId,
+  }) {
+    final key = _attachmentJobKey(messageId, transcriptId);
+    _attachmentJob[key] = job;
+    if (job is _AttachmentDownloadJob) {
+      DownloadKeyValue.instance.addMessageId(key);
+    }
   }
 
-  Future<bool> cancelProgressAttachmentJob(String messageId) async {
-    await _messageDao.updateMediaStatus(messageId, MediaStatus.canceled);
-    if (!_hasAttachmentJob(messageId)) {
+  Future<void> removeAttachmentJob(
+    String messageId, {
+    String? transcriptId,
+  }) async {
+    final key = _attachmentJobKey(messageId, transcriptId);
+    await DownloadKeyValue.instance.removeMessageId(key);
+    _attachmentJob[key]?.cancel();
+    _attachmentJob.remove(key);
+  }
+
+  Future<bool> cancelProgressAttachmentJob(
+    String messageId, {
+    String? transcriptId,
+  }) async {
+    await _messageDao.updateMediaStatus(
+      messageId,
+      MediaStatus.canceled,
+      transcriptId: transcriptId,
+    );
+    final hasJob = _hasAttachmentJob(messageId, transcriptId: transcriptId);
+    await removeAttachmentJob(messageId, transcriptId: transcriptId);
+    if (!hasJob) {
       w('cancelProgressAttachmentJob: no job for $messageId');
       return false;
     }
-    await DownloadKeyValue.instance.removeMessageId(messageId);
-    _attachmentJob[messageId]?.cancel();
-    _attachmentJob.remove(messageId);
     return true;
   }
 
-  double getAttachmentProgress(String messageId) =>
-      _attachmentJob[messageId]?.progress ?? 0;
+  double getAttachmentProgress(
+    String messageId, {
+    String? transcriptId,
+  }) =>
+      _attachmentJob[_attachmentJobKey(messageId, transcriptId)]?.progress ?? 0;
 
   Future<bool> syncMessageMedia(String messageId) async {
     Future<bool> fromMessage() async {
@@ -578,12 +718,16 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
     return result.any((result) => result);
   }
 
-  Future _updateTranscriptMessageStatus(String messageId) async {
-    final transcriptIds =
-        (await _transcriptMessageDao
-                .transcriptMessageByMessageId(messageId, maxLimit)
-                .get())
-            .map((e) => e.transcriptId);
+  Future _updateTranscriptMessageStatus(
+    String messageId, {
+    String? transcriptId,
+  }) async {
+    final transcriptIds = transcriptId != null
+        ? [transcriptId]
+        : (await _transcriptMessageDao
+                  .transcriptMessageByMessageId(messageId, maxLimit)
+                  .get())
+              .map((e) => e.transcriptId);
     await Future.forEach<String>(transcriptIds, (transcriptId) async {
       final list = await _transcriptMessageDao
           .transcriptMessageByTranscriptId(transcriptId)

--- a/lib/utils/attachment/attachment_util.dart
+++ b/lib/utils/attachment/attachment_util.dart
@@ -106,11 +106,8 @@ class AttachmentUtilBase {
   }) {
     if (fileName?.trim().isEmpty ?? true) return '';
     if (isTranscript) {
-      var name = '$messageId${fileName!.fileExtension}';
-      if (messageId == null) {
-        name = fileName;
-      }
-      return p.join(transcriptPath, name);
+      if (p.isAbsolute(fileName!)) return fileName;
+      return p.join(transcriptPath, fileName);
     }
     if (fileName?.startsWith(mixinDocumentsDirectory.path) == true) {
       return fileName!;
@@ -343,6 +340,7 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
       message?.name ?? transcriptMessage?.mediaName,
       mimeType: mediaMimeType,
       isTranscript: transcriptId != null || message == null,
+      transcriptId: transcriptId,
     );
     final path = file.absolute.path;
     if (file.existsSync()) await file.delete();
@@ -563,6 +561,7 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
     String? mediaName, {
     String? mimeType,
     bool isTranscript = false,
+    String? transcriptId,
   }) {
     final path = isTranscript
         ? transcriptPath
@@ -585,7 +584,10 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
     } else {
       suffix = mediaName?.fileExtension ?? '';
     }
-    return File(p.join(path, '$messageId$suffix'));
+    final name = isTranscript && transcriptId != null
+        ? '$transcriptId-$messageId$suffix'
+        : '$messageId$suffix';
+    return File(p.join(path, name));
   }
 
   bool _equalsIgnoreCase(String? string1, String? string2) =>

--- a/lib/utils/attachment/attachment_util.dart
+++ b/lib/utils/attachment/attachment_util.dart
@@ -196,14 +196,12 @@ class AttachmentUtil extends AttachmentUtilBase with ChangeNotifier {
       return transcriptMessage?.mediaStatus == MediaStatus.done;
     }
 
-    Future<bool> checkDownloaded() async =>
-        await _messageDao.messageHasMediaStatus(messageId, MediaStatus.done) ||
-        await _messageDao.transcriptMessageHasMediaStatus(
-          messageId,
-          MediaStatus.done,
-        );
-
-    if (!_hasAttachmentJob(messageId) && await checkDownloaded()) {
+    if (!_hasAttachmentJob(messageId) &&
+        (await _messageDao.messageHasMediaStatus(messageId, MediaStatus.done) ||
+            await _messageDao.transcriptMessageHasMediaStatus(
+              messageId,
+              MediaStatus.done,
+            ))) {
       await syncMessageMedia(messageId);
       await _updateTranscriptMessageStatus(messageId);
       return true;

--- a/lib/widgets/message/item/audio_message.dart
+++ b/lib/widgets/message/item/audio_message.dart
@@ -25,9 +25,7 @@ class AudioMessage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isTranscriptPage = useIsTranscriptPage();
-    final transcriptId = isTranscriptPage
-        ? TranscriptPage.of(context)?.messageId
-        : null;
+    final transcriptId = TranscriptPage.of(context)?.messageId;
     final messageId = useMessageConverter(
       converter: (state) => state.messageId,
     );

--- a/lib/widgets/message/item/audio_message.dart
+++ b/lib/widgets/message/item/audio_message.dart
@@ -25,6 +25,9 @@ class AudioMessage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isTranscriptPage = useIsTranscriptPage();
+    final transcriptId = isTranscriptPage
+        ? TranscriptPage.of(context)?.messageId
+        : null;
     final messageId = useMessageConverter(
       converter: (state) => state.messageId,
     );
@@ -89,11 +92,15 @@ class AudioMessage extends HookConsumerWidget {
                   context.accountServer.reUploadAttachment(message);
                 }
               } else {
-                context.accountServer.downloadAttachment(message.messageId);
+                context.accountServer.downloadAttachment(
+                  message.messageId,
+                  transcriptId: transcriptId,
+                );
               }
             case MediaStatus.pending:
               context.accountServer.cancelProgressAttachmentJob(
                 message.messageId,
+                transcriptId: transcriptId,
               );
             case MediaStatus.expired:
             case null:
@@ -111,7 +118,9 @@ class AudioMessage extends HookConsumerWidget {
                         ? const StatusUpload()
                         : const StatusDownload();
                   case MediaStatus.pending:
-                    return const StatusPending();
+                    return StatusPending(
+                      transcriptId: transcriptId,
+                    );
                   case MediaStatus.expired:
                     return const StatusWarning();
                   case MediaStatus.done:

--- a/lib/widgets/message/item/file_message.dart
+++ b/lib/widgets/message/item/file_message.dart
@@ -36,9 +36,7 @@ class MessageFile extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isTranscriptPage = useIsTranscriptPage();
-    final transcriptId = isTranscriptPage
-        ? TranscriptPage.of(context)?.messageId
-        : null;
+    final transcriptId = TranscriptPage.of(context)?.messageId;
     final mediaStatus = useMessageConverter(
       converter: (state) => state.mediaStatus,
     );

--- a/lib/widgets/message/item/file_message.dart
+++ b/lib/widgets/message/item/file_message.dart
@@ -36,6 +36,9 @@ class MessageFile extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isTranscriptPage = useIsTranscriptPage();
+    final transcriptId = isTranscriptPage
+        ? TranscriptPage.of(context)?.messageId
+        : null;
     final mediaStatus = useMessageConverter(
       converter: (state) => state.mediaStatus,
     );
@@ -85,7 +88,10 @@ class MessageFile extends HookConsumerWidget {
               await context.accountServer.reUploadAttachment(message);
             }
           } else {
-            await context.accountServer.downloadAttachment(message.messageId);
+            await context.accountServer.downloadAttachment(
+              message.messageId,
+              transcriptId: transcriptId,
+            );
           }
         } else if (message.mediaStatus == MediaStatus.done &&
             message.mediaUrl != null) {
@@ -115,6 +121,7 @@ class MessageFile extends HookConsumerWidget {
         } else if (message.mediaStatus == MediaStatus.pending) {
           await context.accountServer.cancelProgressAttachmentJob(
             message.messageId,
+            transcriptId: transcriptId,
           );
         }
       },
@@ -129,7 +136,9 @@ class MessageFile extends HookConsumerWidget {
                       ? const StatusUpload()
                       : const StatusDownload();
                 case MediaStatus.pending:
-                  return const StatusPending();
+                  return StatusPending(
+                    transcriptId: transcriptId,
+                  );
                 case MediaStatus.expired:
                   return const StatusWarning();
                 case null:

--- a/lib/widgets/message/item/image/image_message.dart
+++ b/lib/widgets/message/item/image/image_message.dart
@@ -75,9 +75,7 @@ class MessageImage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isTranscriptPage = useIsTranscriptPage();
-    final transcriptId = isTranscriptPage
-        ? TranscriptPage.of(context)?.messageId
-        : null;
+    final transcriptId = TranscriptPage.of(context)?.messageId;
     final isPinnedPage = useIsPinnedPage();
     final type = useMessageConverter(converter: (state) => state.type);
     final conversationId = useMessageConverter(

--- a/lib/widgets/message/item/image/image_message.dart
+++ b/lib/widgets/message/item/image/image_message.dart
@@ -75,6 +75,9 @@ class MessageImage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isTranscriptPage = useIsTranscriptPage();
+    final transcriptId = isTranscriptPage
+        ? TranscriptPage.of(context)?.messageId
+        : null;
     final isPinnedPage = useIsPinnedPage();
     final type = useMessageConverter(converter: (state) => state.type);
     final conversationId = useMessageConverter(
@@ -165,11 +168,15 @@ class MessageImage extends HookConsumerWidget {
                 context.accountServer.reUploadAttachment(message);
               }
             } else {
-              context.accountServer.downloadAttachment(message.messageId);
+              context.accountServer.downloadAttachment(
+                message.messageId,
+                transcriptId: transcriptId,
+              );
             }
           case MediaStatus.pending:
             context.accountServer.cancelProgressAttachmentJob(
               message.messageId,
+              transcriptId: transcriptId,
             );
           case null:
           case MediaStatus.expired:
@@ -207,7 +214,9 @@ class MessageImage extends HookConsumerWidget {
                           ? const StatusUpload()
                           : const StatusDownload();
                     case MediaStatus.pending:
-                      return const StatusPending();
+                      return StatusPending(
+                        transcriptId: transcriptId,
+                      );
                     case MediaStatus.expired:
                       return const StatusWarning();
                     case MediaStatus.done:

--- a/lib/widgets/message/item/video/video_message.dart
+++ b/lib/widgets/message/item/video/video_message.dart
@@ -75,9 +75,7 @@ class MessageVideo extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isCurrentUser = useIsCurrentUser();
     final isTranscriptPage = useIsTranscriptPage();
-    final transcriptId = isTranscriptPage
-        ? TranscriptPage.of(context)?.messageId
-        : null;
+    final transcriptId = TranscriptPage.of(context)?.messageId;
 
     final thumbImage = useMessageConverter(
       converter: (state) => state.thumbImage,
@@ -171,9 +169,7 @@ class VideoMessageMediaStatusWidget extends HookConsumerWidget {
     final mediaUrl = useMessageConverter(converter: (state) => state.mediaUrl);
 
     final isTranscriptPage = useIsTranscriptPage();
-    final transcriptId = isTranscriptPage
-        ? TranscriptPage.of(context)?.messageId
-        : null;
+    final transcriptId = TranscriptPage.of(context)?.messageId;
     final isMessageSentOut =
         (isTranscriptPage &&
             TranscriptPage.of(context)?.relationship == UserRelationship.me) ||

--- a/lib/widgets/message/item/video/video_message.dart
+++ b/lib/widgets/message/item/video/video_message.dart
@@ -75,6 +75,9 @@ class MessageVideo extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isCurrentUser = useIsCurrentUser();
     final isTranscriptPage = useIsTranscriptPage();
+    final transcriptId = isTranscriptPage
+        ? TranscriptPage.of(context)?.messageId
+        : null;
 
     final thumbImage = useMessageConverter(
       converter: (state) => state.thumbImage,
@@ -104,7 +107,10 @@ class MessageVideo extends HookConsumerWidget {
               context.accountServer.reUploadAttachment(message);
             }
           } else {
-            context.accountServer.downloadAttachment(message.messageId);
+            context.accountServer.downloadAttachment(
+              message.messageId,
+              transcriptId: transcriptId,
+            );
           }
         } else if (message.mediaStatus == MediaStatus.done &&
             message.mediaUrl != null) {
@@ -125,7 +131,10 @@ class MessageVideo extends HookConsumerWidget {
             openUri(context, Uri.file(path).toString());
           }
         } else if (message.mediaStatus == MediaStatus.pending) {
-          context.accountServer.cancelProgressAttachmentJob(message.messageId);
+          context.accountServer.cancelProgressAttachmentJob(
+            message.messageId,
+            transcriptId: transcriptId,
+          );
         } else if (message.type.isLive && message.mediaUrl != null) {
           launchUrlString(message.mediaUrl!);
         }
@@ -162,6 +171,9 @@ class VideoMessageMediaStatusWidget extends HookConsumerWidget {
     final mediaUrl = useMessageConverter(converter: (state) => state.mediaUrl);
 
     final isTranscriptPage = useIsTranscriptPage();
+    final transcriptId = isTranscriptPage
+        ? TranscriptPage.of(context)?.messageId
+        : null;
     final isMessageSentOut =
         (isTranscriptPage &&
             TranscriptPage.of(context)?.relationship == UserRelationship.me) ||
@@ -173,7 +185,9 @@ class VideoMessageMediaStatusWidget extends HookConsumerWidget {
             ? const StatusUpload()
             : const StatusDownload();
       case MediaStatus.pending:
-        return const StatusPending();
+        return StatusPending(
+          transcriptId: transcriptId,
+        );
       case MediaStatus.expired:
         return const StatusWarning();
       case MediaStatus.done:

--- a/lib/widgets/status.dart
+++ b/lib/widgets/status.dart
@@ -8,7 +8,9 @@ import '../utils/hook.dart';
 import 'message/message.dart';
 
 class StatusPending extends HookConsumerWidget {
-  const StatusPending({super.key});
+  const StatusPending({super.key, this.transcriptId});
+
+  final String? transcriptId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -18,9 +20,11 @@ class StatusPending extends HookConsumerWidget {
 
     final value = useListenableConverter(
       context.accountServer.attachmentUtil,
-      converter: (attachmentUtil) =>
-          attachmentUtil.getAttachmentProgress(messageId),
-      keys: [messageId],
+      converter: (attachmentUtil) => attachmentUtil.getAttachmentProgress(
+        messageId,
+        transcriptId: transcriptId,
+      ),
+      keys: [messageId, transcriptId],
     ).requireData;
 
     return _StatusPending(value: value);

--- a/lib/workers/decrypt_message.dart
+++ b/lib/workers/decrypt_message.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:drift/drift.dart';
+
 import 'package:ed25519_edwards/ed25519_edwards.dart' as ed;
+import 'package:flutter/foundation.dart';
 import 'package:libsignal_protocol_dart/libsignal_protocol_dart.dart';
 import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
 import 'package:uuid/uuid.dart';
@@ -50,6 +52,16 @@ import 'job/update_sticker_job.dart';
 import 'job/update_token_job.dart';
 import 'message_worker_isolate.dart';
 import 'sender.dart';
+
+@visibleForTesting
+TranscriptMessage normalizeIncomingTranscriptMessage(
+  TranscriptMessage transcript,
+) => transcript.category.isAttachment
+    ? transcript.copyWith(
+        mediaUrl: const Value(null),
+        mediaStatus: const Value(MediaStatus.canceled),
+      )
+    : transcript;
 
 class DecryptMessage extends Injector {
   DecryptMessage(
@@ -1577,14 +1589,7 @@ class DecryptMessage extends Injector {
 
     final insertAllTranscriptMessageFuture = database.transcriptMessageDao
         .insertAll(
-          transcripts.map((transcript) {
-            if (transcript.category.isAttachment) {
-              return transcript.copyWith(
-                mediaStatus: const Value(MediaStatus.canceled),
-              );
-            }
-            return transcript;
-          }).toList(),
+          transcripts.map(normalizeIncomingTranscriptMessage).toList(),
         );
 
     await Future.wait([

--- a/lib/workers/job/sending_job.dart
+++ b/lib/workers/job/sending_job.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 
 import 'package:drift/drift.dart';
 import 'package:ed25519_edwards/ed25519_edwards.dart' as ed;
+import 'package:flutter/foundation.dart';
 import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
 import 'package:mixin_logger/mixin_logger.dart';
 import 'package:uuid/uuid.dart';
@@ -29,6 +30,17 @@ import '../../widgets/message/item/action_card/action_card_data.dart';
 import '../../widgets/message/send_message_dialog/attachment_extra.dart';
 import '../job_queue.dart';
 import '../sender.dart';
+
+@visibleForTesting
+Map<String, dynamic> transcriptMessageToSendingJson(
+  TranscriptMessage message,
+) {
+  final map = message.toJson(serializer: const UtcValueSerializer())
+    ..['media_duration'] = int.tryParse(message.mediaDuration ?? '')
+    ..remove('media_status')
+    ..remove('media_url');
+  return map;
+}
 
 class SendingJob extends JobQueue<Job, List<Job>> {
   SendingJob({
@@ -199,11 +211,7 @@ class SendingJob extends JobQueue<Job, List<Job>> {
           }
         }
 
-        final map = e.toJson(serializer: const UtcValueSerializer());
-        map['media_duration'] = int.tryParse(
-          map['media_duration'] as String? ?? '',
-        );
-        map.remove('media_status');
+        final map = transcriptMessageToSendingJson(e);
         return map;
       }).toList();
       message = message.copyWith(content: await jsonEncodeWithIsolate(json));

--- a/test/utils/attachment_util_test.dart
+++ b/test/utils/attachment_util_test.dart
@@ -50,16 +50,39 @@ class _DeletingTranscriptAttachmentUtil extends AttachmentUtil {
     );
     final parentId = transcriptId!;
     await removeAttachmentJobsByParentId(parentId);
-    await (_database.delete(_database.transcriptMessages)
-          ..where(
-            (row) =>
-                row.transcriptId.equals(parentId) &
-                row.messageId.equals(messageId),
-          ))
+    await (_database.delete(_database.transcriptMessages)..where(
+          (row) =>
+              row.transcriptId.equals(parentId) &
+              row.messageId.equals(messageId),
+        ))
         .go();
     isNotPendingReturned.complete();
     return result;
   }
+}
+
+class _AttachmentTestContext {
+  _AttachmentTestContext(this.database, this.mediaDirectory);
+
+  static Future<_AttachmentTestContext> create(String key) async {
+    final database = MixinDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+    final documentsDirectory = await Directory.systemTemp.createTemp(
+      'attachment-util-documents',
+    );
+    mixinDocumentsDirectory = documentsDirectory;
+    addTearDown(() => documentsDirectory.delete(recursive: true));
+    await DownloadKeyValue.instance.init(key);
+    addTearDown(DownloadKeyValue.instance.delete);
+    final mediaDirectory = await Directory.systemTemp.createTemp(
+      'attachment-util-test',
+    );
+    addTearDown(() => mediaDirectory.delete(recursive: true));
+    return _AttachmentTestContext(database, mediaDirectory);
+  }
+
+  final MixinDatabase database;
+  final Directory mediaDirectory;
 }
 
 void main() {
@@ -101,20 +124,11 @@ void main() {
   });
 
   test('downloads the requested transcript child once by both IDs', () async {
-    final database = MixinDatabase(NativeDatabase.memory());
-    addTearDown(database.close);
-    final documentsDirectory = await Directory.systemTemp.createTemp(
-      'attachment-util-documents',
+    final context = await _AttachmentTestContext.create(
+      'attachment-util-exact',
     );
-    mixinDocumentsDirectory = documentsDirectory;
-    addTearDown(() => documentsDirectory.delete(recursive: true));
-    await DownloadKeyValue.instance.init('attachment-util-exact');
-    addTearDown(DownloadKeyValue.instance.delete);
-
-    final mediaDirectory = await Directory.systemTemp.createTemp(
-      'attachment-util-test',
-    );
-    addTearDown(() => mediaDirectory.delete(recursive: true));
+    final database = context.database;
+    final mediaDirectory = context.mediaDirectory;
 
     await database.transcriptMessageDao.insertAll([
       TranscriptMessage(
@@ -204,20 +218,11 @@ void main() {
   test(
     'aborts an in-flight transcript download when its row is deleted',
     () async {
-      final database = MixinDatabase(NativeDatabase.memory());
-      addTearDown(database.close);
-      final documentsDirectory = await Directory.systemTemp.createTemp(
-        'attachment-util-documents',
+      final context = await _AttachmentTestContext.create(
+        'attachment-util-deleted-row',
       );
-      mixinDocumentsDirectory = documentsDirectory;
-      addTearDown(() => documentsDirectory.delete(recursive: true));
-      await DownloadKeyValue.instance.init('attachment-util-deleted-row');
-      addTearDown(DownloadKeyValue.instance.delete);
-
-      final mediaDirectory = await Directory.systemTemp.createTemp(
-        'attachment-util-test',
-      );
-      addTearDown(() => mediaDirectory.delete(recursive: true));
+      final database = context.database;
+      final mediaDirectory = context.mediaDirectory;
 
       const transcriptId = 'deleted-parent';
       const messageId = 'deleted-child';
@@ -279,12 +284,11 @@ void main() {
         transcriptId: transcriptId,
       );
       await requestReceived.future;
-      await (database.delete(database.transcriptMessages)
-            ..where(
-              (row) =>
-                  row.transcriptId.equals(transcriptId) &
-                  row.messageId.equals(messageId),
-            ))
+      await (database.delete(database.transcriptMessages)..where(
+            (row) =>
+                row.transcriptId.equals(transcriptId) &
+                row.messageId.equals(messageId),
+          ))
           .go();
 
       try {
@@ -304,22 +308,11 @@ void main() {
   test(
     'does not recreate a deleted transcript attachment job after pending check',
     () async {
-      final database = MixinDatabase(NativeDatabase.memory());
-      addTearDown(database.close);
-      final documentsDirectory = await Directory.systemTemp.createTemp(
-        'attachment-util-documents',
-      );
-      mixinDocumentsDirectory = documentsDirectory;
-      addTearDown(() => documentsDirectory.delete(recursive: true));
-      await DownloadKeyValue.instance.init(
+      final context = await _AttachmentTestContext.create(
         'attachment-util-deleted-after-pending',
       );
-      addTearDown(DownloadKeyValue.instance.delete);
-
-      final mediaDirectory = await Directory.systemTemp.createTemp(
-        'attachment-util-test',
-      );
-      addTearDown(() => mediaDirectory.delete(recursive: true));
+      final database = context.database;
+      final mediaDirectory = context.mediaDirectory;
 
       const transcriptId = 'deleted-after-pending-parent';
       const messageId = 'deleted-after-pending-child';
@@ -401,20 +394,11 @@ void main() {
   test(
     'removes persisted attachment jobs by parent without sibling leakage',
     () async {
-      final database = MixinDatabase(NativeDatabase.memory());
-      addTearDown(database.close);
-      final documentsDirectory = await Directory.systemTemp.createTemp(
-        'attachment-util-documents',
+      final context = await _AttachmentTestContext.create(
+        'attachment-util-parent-cleanup',
       );
-      mixinDocumentsDirectory = documentsDirectory;
-      addTearDown(() => documentsDirectory.delete(recursive: true));
-      await DownloadKeyValue.instance.init('attachment-util-parent-cleanup');
-      addTearDown(DownloadKeyValue.instance.delete);
-
-      final mediaDirectory = await Directory.systemTemp.createTemp(
-        'attachment-util-test',
-      );
-      addTearDown(() => mediaDirectory.delete(recursive: true));
+      final database = context.database;
+      final mediaDirectory = context.mediaDirectory;
 
       final util = AttachmentUtil(
         Client(

--- a/test/utils/attachment_util_test.dart
+++ b/test/utils/attachment_util_test.dart
@@ -20,6 +20,48 @@ import 'package:flutter_app/workers/job/sending_job.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
 
+class _DeletingTranscriptAttachmentUtil extends AttachmentUtil {
+  _DeletingTranscriptAttachmentUtil(
+    Client client,
+    MixinDatabase database,
+    SettingPropertyStorage settingProperties,
+    String mediaPath, {
+    required this.isNotPendingReturned,
+  }) : _database = database,
+       super(
+         client,
+         database.messageDao,
+         database.transcriptMessageDao,
+         settingProperties,
+         mediaPath,
+       );
+
+  final MixinDatabase _database;
+  final Completer<void> isNotPendingReturned;
+
+  @override
+  Future<bool> isNotPending(
+    String messageId, {
+    String? transcriptId,
+  }) async {
+    final result = await super.isNotPending(
+      messageId,
+      transcriptId: transcriptId,
+    );
+    final parentId = transcriptId!;
+    await removeAttachmentJobsByParentId(parentId);
+    await (_database.delete(_database.transcriptMessages)
+          ..where(
+            (row) =>
+                row.transcriptId.equals(parentId) &
+                row.messageId.equals(messageId),
+          ))
+        .go();
+    isNotPendingReturned.complete();
+    return result;
+  }
+}
+
 void main() {
   setUpAll(EventBus.initialize);
   test('clears stale media paths for incoming transcript attachments', () {
@@ -256,6 +298,103 @@ void main() {
       }
 
       expect(DownloadKeyValue.instance.messageIds, isNot(contains(key)));
+    },
+  );
+
+  test(
+    'does not recreate a deleted transcript attachment job after pending check',
+    () async {
+      final database = MixinDatabase(NativeDatabase.memory());
+      addTearDown(database.close);
+      final documentsDirectory = await Directory.systemTemp.createTemp(
+        'attachment-util-documents',
+      );
+      mixinDocumentsDirectory = documentsDirectory;
+      addTearDown(() => documentsDirectory.delete(recursive: true));
+      await DownloadKeyValue.instance.init(
+        'attachment-util-deleted-after-pending',
+      );
+      addTearDown(DownloadKeyValue.instance.delete);
+
+      final mediaDirectory = await Directory.systemTemp.createTemp(
+        'attachment-util-test',
+      );
+      addTearDown(() => mediaDirectory.delete(recursive: true));
+
+      const transcriptId = 'deleted-after-pending-parent';
+      const messageId = 'deleted-after-pending-child';
+      const attachmentId = 'deleted-after-pending-attachment';
+      const key = '$transcriptId|$messageId';
+
+      await database.transcriptMessageDao.insertAll([
+        TranscriptMessage(
+          transcriptId: transcriptId,
+          messageId: messageId,
+          category: MessageCategory.plainImage,
+          createdAt: DateTime(2026),
+          content: attachmentId,
+          mediaMimeType: 'image/png',
+          mediaStatus: MediaStatus.canceled,
+        ),
+      ]);
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final releaseFileResponse = Completer<void>();
+      final baseUrl = 'http://${server.address.host}:${server.port}';
+      final subscription = server.listen((request) async {
+        final response = request.response;
+        if (request.uri.path == '/attachments/$attachmentId') {
+          response.headers.contentType = ContentType.json;
+          response.write(
+            jsonEncode({
+              'data': {
+                'attachment_id': attachmentId,
+                'created_at': '2026-01-01T00:00:00Z',
+                'view_url': '$baseUrl/files/$attachmentId',
+              },
+            }),
+          );
+        } else if (request.uri.path == '/files/$attachmentId') {
+          await releaseFileResponse.future;
+          response.add([1, 2, 3]);
+        } else {
+          response.statusCode = HttpStatus.notFound;
+        }
+        await response.close();
+      });
+      addTearDown(() async {
+        if (!releaseFileResponse.isCompleted) releaseFileResponse.complete();
+        await subscription.cancel();
+        await server.close(force: true);
+      });
+
+      final util = _DeletingTranscriptAttachmentUtil(
+        Client(baseUrl: baseUrl, accessToken: 'test', httpLogLevel: null),
+        database,
+        SettingPropertyStorage(database.propertyDao),
+        mediaDirectory.path,
+        isNotPendingReturned: Completer<void>(),
+      );
+
+      final download = util.downloadAttachment(
+        messageId: messageId,
+        transcriptId: transcriptId,
+      );
+      try {
+        await util.isNotPendingReturned.future;
+        await Future<void>.delayed(Duration.zero);
+
+        expect(DownloadKeyValue.instance.messageIds, isNot(contains(key)));
+        expect(
+          util.downloadingParentIds,
+          isNot(contains(transcriptId)),
+        );
+      } finally {
+        if (!releaseFileResponse.isCompleted) {
+          releaseFileResponse.complete();
+        }
+        await download;
+      }
     },
   );
 

--- a/test/utils/attachment_util_test.dart
+++ b/test/utils/attachment_util_test.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_app/db/mixin_database.dart';
 import 'package:flutter_app/enum/media_status.dart';
@@ -59,6 +59,52 @@ class _DeletingTranscriptAttachmentUtil extends AttachmentUtil {
     isNotPendingReturned.complete();
     return result;
   }
+}
+
+class _RecordingTranscriptAttachmentUtil extends AttachmentUtil {
+  _RecordingTranscriptAttachmentUtil(
+    Client client,
+    MixinDatabase database,
+    SettingPropertyStorage settingProperties,
+    String mediaPath,
+  ) : super(
+        client,
+        database.messageDao,
+        database.transcriptMessageDao,
+        settingProperties,
+        mediaPath,
+      );
+
+  final paths = <String>[];
+
+  @override
+  File getAttachmentFile(
+    String category,
+    String? conversationId,
+    String messageId,
+    String? mediaName, {
+    String? mimeType,
+    bool isTranscript = false,
+    String? transcriptId,
+  }) {
+    final file = super.getAttachmentFile(
+      category,
+      conversationId,
+      messageId,
+      mediaName,
+      mimeType: mimeType,
+      isTranscript: isTranscript,
+      transcriptId: transcriptId,
+    );
+    paths.add(file.path);
+    return file;
+  }
+
+  @override
+  Future<bool> isNotPending(
+    String messageId, {
+    String? transcriptId,
+  }) async => true;
 }
 
 class _AttachmentTestContext {
@@ -214,6 +260,119 @@ void main() {
     expect(other.mediaStatus, MediaStatus.canceled);
     expect(requestedPaths, ['/attachments/target-attachment']);
   });
+  test(
+    'isolates concurrent transcript downloads with the same child ID',
+    () async {
+      final context = await _AttachmentTestContext.create(
+        'attachment-util-transcript-isolation',
+      );
+      final database = context.database;
+      final mediaDirectory = context.mediaDirectory;
+
+      const firstTranscriptId = 'first-transcript';
+      const secondTranscriptId = 'second-transcript';
+      const childMessageId = 'shared-child-id';
+      const firstAttachmentId = 'first-attachment';
+      const secondAttachmentId = 'second-attachment';
+
+      await database.transcriptMessageDao.insertAll([
+        TranscriptMessage(
+          transcriptId: firstTranscriptId,
+          messageId: childMessageId,
+          category: MessageCategory.plainImage,
+          createdAt: DateTime(2026),
+          content: firstAttachmentId,
+          mediaMimeType: 'image/png',
+          mediaWidth: 1,
+          mediaHeight: 1,
+          mediaStatus: MediaStatus.canceled,
+        ),
+        TranscriptMessage(
+          transcriptId: secondTranscriptId,
+          messageId: childMessageId,
+          category: MessageCategory.plainImage,
+          createdAt: DateTime(2026),
+          content: secondAttachmentId,
+          mediaMimeType: 'image/png',
+          mediaWidth: 1,
+          mediaHeight: 1,
+          mediaStatus: MediaStatus.canceled,
+        ),
+      ]);
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final requestedAttachmentIds = <String>[];
+      final metadataRequestsReceived = Completer<void>();
+      final baseUrl = 'http://${server.address.host}:${server.port}';
+      final subscription = server.listen((request) async {
+        final attachmentId = request.uri.path.substring(
+          '/attachments/'.length,
+        );
+        requestedAttachmentIds.add(attachmentId);
+        if (requestedAttachmentIds.length == 2) {
+          metadataRequestsReceived.complete();
+        }
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'data': {
+              'attachment_id': attachmentId,
+              'created_at': '2026-01-01T00:00:00Z',
+              'view_url': null,
+            },
+          }),
+        );
+        await request.response.close();
+      });
+      addTearDown(() async {
+        await subscription.cancel();
+        await server.close(force: true);
+      });
+
+      final util = _RecordingTranscriptAttachmentUtil(
+        Client(baseUrl: baseUrl, accessToken: 'test', httpLogLevel: null),
+        database,
+        SettingPropertyStorage(database.propertyDao),
+        mediaDirectory.path,
+      );
+
+      final downloads = Future.wait([
+        util.downloadAttachment(
+          messageId: childMessageId,
+          transcriptId: firstTranscriptId,
+        ),
+        util.downloadAttachment(
+          messageId: childMessageId,
+          transcriptId: secondTranscriptId,
+        ),
+      ]);
+      await metadataRequestsReceived.future;
+      await downloads;
+
+      expect(
+        requestedAttachmentIds.toSet(),
+        {firstAttachmentId, secondAttachmentId},
+      );
+      expect(util.paths.toSet(), hasLength(2));
+      expect(
+        util.paths.singleWhere((path) => path.contains(firstTranscriptId)),
+        contains(childMessageId),
+      );
+      expect(
+        util.paths.singleWhere((path) => path.contains(secondTranscriptId)),
+        contains(childMessageId),
+      );
+      expect(
+        util.convertAbsolutePath(
+          category: MessageCategory.plainImage,
+          fileName: null,
+          messageId: childMessageId,
+          isTranscript: true,
+        ),
+        '',
+      );
+    },
+  );
 
   test(
     'aborts an in-flight transcript download when its row is deleted',

--- a/test/utils/attachment_util_test.dart
+++ b/test/utils/attachment_util_test.dart
@@ -1,0 +1,323 @@
+@TestOn('linux || mac-os')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_app/db/mixin_database.dart';
+import 'package:flutter_app/enum/media_status.dart';
+import 'package:flutter_app/enum/message_category.dart';
+import 'package:flutter_app/utils/attachment/attachment_util.dart';
+import 'package:flutter_app/utils/attachment/download_key_value.dart';
+import 'package:flutter_app/utils/event_bus.dart';
+import 'package:flutter_app/utils/file.dart';
+import 'package:flutter_app/utils/property/setting_property.dart';
+import 'package:flutter_app/workers/decrypt_message.dart';
+import 'package:flutter_app/workers/job/sending_job.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
+
+void main() {
+  setUpAll(EventBus.initialize);
+  test('clears stale media paths for incoming transcript attachments', () {
+    final message = TranscriptMessage(
+      transcriptId: 'transcript-id',
+      messageId: 'child-id',
+      category: MessageCategory.plainImage,
+      createdAt: DateTime(2026),
+      content: 'attachment-id',
+      mediaUrl: 'stale.png',
+      mediaStatus: MediaStatus.done,
+    );
+
+    final normalized = normalizeIncomingTranscriptMessage(message);
+
+    expect(normalized.mediaUrl, isNull);
+    expect(normalized.mediaStatus, MediaStatus.canceled);
+  });
+  test('omits local media paths from outgoing transcript JSON', () {
+    final json = transcriptMessageToSendingJson(
+      TranscriptMessage(
+        transcriptId: 'transcript-id',
+        messageId: 'child-id',
+        category: MessageCategory.plainImage,
+        createdAt: DateTime(2026),
+        content: 'attachment-id',
+        mediaUrl: 'local.png',
+        mediaDuration: '42',
+        mediaStatus: MediaStatus.canceled,
+      ),
+    );
+
+    expect(json['content'], 'attachment-id');
+    expect(json['media_duration'], 42);
+    expect(json.containsKey('media_url'), isFalse);
+    expect(json.containsKey('media_status'), isFalse);
+  });
+
+  test('downloads the requested transcript child once by both IDs', () async {
+    final database = MixinDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+    final documentsDirectory = await Directory.systemTemp.createTemp(
+      'attachment-util-documents',
+    );
+    mixinDocumentsDirectory = documentsDirectory;
+    addTearDown(() => documentsDirectory.delete(recursive: true));
+    await DownloadKeyValue.instance.init('attachment-util-exact');
+    addTearDown(DownloadKeyValue.instance.delete);
+
+    final mediaDirectory = await Directory.systemTemp.createTemp(
+      'attachment-util-test',
+    );
+    addTearDown(() => mediaDirectory.delete(recursive: true));
+
+    await database.transcriptMessageDao.insertAll([
+      TranscriptMessage(
+        transcriptId: 'target-transcript',
+        messageId: 'child-id',
+        category: MessageCategory.plainImage,
+        createdAt: DateTime(2026),
+        content: 'target-attachment',
+        mediaUrl: 'stale.png',
+        mediaMimeType: 'image/png',
+        mediaWidth: 1,
+        mediaHeight: 1,
+        mediaStatus: MediaStatus.canceled,
+      ),
+      TranscriptMessage(
+        transcriptId: 'other-transcript',
+        messageId: 'child-id',
+        category: MessageCategory.plainImage,
+        createdAt: DateTime(2026),
+        content: 'other-attachment',
+        mediaMimeType: 'image/png',
+        mediaSize: 3,
+        mediaWidth: 1,
+        mediaHeight: 1,
+        mediaStatus: MediaStatus.canceled,
+      ),
+    ]);
+
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final requestedPaths = <String>[];
+    final baseUrl = 'http://${server.address.host}:${server.port}';
+    final subscription = server.listen((request) async {
+      requestedPaths.add(request.uri.path);
+      final response = request.response;
+      if (request.uri.path == '/attachments/target-attachment') {
+        response.headers.contentType = ContentType.json;
+        response.write(
+          jsonEncode({
+            'data': {
+              'attachment_id': 'target-attachment',
+              'created_at': '2026-01-01T00:00:00Z',
+              'view_url': null,
+            },
+          }),
+        );
+      } else {
+        response.statusCode = HttpStatus.notFound;
+      }
+      await response.close();
+    });
+    addTearDown(() async {
+      await subscription.cancel();
+      await server.close(force: true);
+    });
+
+    final util = AttachmentUtil(
+      Client(baseUrl: baseUrl, accessToken: 'test', httpLogLevel: null),
+      database.messageDao,
+      database.transcriptMessageDao,
+      SettingPropertyStorage(database.propertyDao),
+      mediaDirectory.path,
+    );
+
+    await Future.wait([
+      util.downloadAttachment(
+        messageId: 'child-id',
+        transcriptId: 'target-transcript',
+      ),
+      util.downloadAttachment(
+        messageId: 'child-id',
+        transcriptId: 'target-transcript',
+      ),
+    ]);
+
+    final target = await database.transcriptMessageDao
+        .transcriptMessageByIds('target-transcript', 'child-id')
+        .getSingle();
+    final other = await database.transcriptMessageDao
+        .transcriptMessageByIds('other-transcript', 'child-id')
+        .getSingle();
+
+    expect(target.mediaStatus, MediaStatus.pending);
+    expect(other.mediaStatus, MediaStatus.canceled);
+    expect(requestedPaths, ['/attachments/target-attachment']);
+  });
+
+  test(
+    'aborts an in-flight transcript download when its row is deleted',
+    () async {
+      final database = MixinDatabase(NativeDatabase.memory());
+      addTearDown(database.close);
+      final documentsDirectory = await Directory.systemTemp.createTemp(
+        'attachment-util-documents',
+      );
+      mixinDocumentsDirectory = documentsDirectory;
+      addTearDown(() => documentsDirectory.delete(recursive: true));
+      await DownloadKeyValue.instance.init('attachment-util-deleted-row');
+      addTearDown(DownloadKeyValue.instance.delete);
+
+      final mediaDirectory = await Directory.systemTemp.createTemp(
+        'attachment-util-test',
+      );
+      addTearDown(() => mediaDirectory.delete(recursive: true));
+
+      const transcriptId = 'deleted-parent';
+      const messageId = 'deleted-child';
+      const attachmentId = 'deleted-attachment';
+      const key = '$transcriptId|$messageId';
+
+      await database.transcriptMessageDao.insertAll([
+        TranscriptMessage(
+          transcriptId: transcriptId,
+          messageId: messageId,
+          category: MessageCategory.plainImage,
+          createdAt: DateTime(2026),
+          content: attachmentId,
+          mediaMimeType: 'image/png',
+          mediaStatus: MediaStatus.pending,
+        ),
+      ]);
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final requestReceived = Completer<void>();
+      final releaseResponse = Completer<void>();
+      final baseUrl = 'http://${server.address.host}:${server.port}';
+      final subscription = server.listen((request) async {
+        final response = request.response;
+        if (request.uri.path == '/attachments/$attachmentId') {
+          requestReceived.complete();
+          await releaseResponse.future;
+          response.headers.contentType = ContentType.json;
+          response.write(
+            jsonEncode({
+              'data': {
+                'attachment_id': attachmentId,
+                'created_at': '2026-01-01T00:00:00Z',
+                'view_url': '$baseUrl/unused',
+              },
+            }),
+          );
+        } else {
+          response.statusCode = HttpStatus.notFound;
+        }
+        await response.close();
+      });
+      addTearDown(() async {
+        if (!releaseResponse.isCompleted) releaseResponse.complete();
+        await subscription.cancel();
+        await server.close(force: true);
+      });
+
+      final util = AttachmentUtil(
+        Client(baseUrl: baseUrl, accessToken: 'test', httpLogLevel: null),
+        database.messageDao,
+        database.transcriptMessageDao,
+        SettingPropertyStorage(database.propertyDao),
+        mediaDirectory.path,
+      );
+
+      final download = util.downloadAttachment(
+        messageId: messageId,
+        transcriptId: transcriptId,
+      );
+      await requestReceived.future;
+      await (database.delete(database.transcriptMessages)
+            ..where(
+              (row) =>
+                  row.transcriptId.equals(transcriptId) &
+                  row.messageId.equals(messageId),
+            ))
+          .go();
+
+      try {
+        expect(
+          await util.isNotPending(messageId, transcriptId: transcriptId),
+          isTrue,
+        );
+      } finally {
+        releaseResponse.complete();
+        await download;
+      }
+
+      expect(DownloadKeyValue.instance.messageIds, isNot(contains(key)));
+    },
+  );
+
+  test(
+    'removes persisted attachment jobs by parent without sibling leakage',
+    () async {
+      final database = MixinDatabase(NativeDatabase.memory());
+      addTearDown(database.close);
+      final documentsDirectory = await Directory.systemTemp.createTemp(
+        'attachment-util-documents',
+      );
+      mixinDocumentsDirectory = documentsDirectory;
+      addTearDown(() => documentsDirectory.delete(recursive: true));
+      await DownloadKeyValue.instance.init('attachment-util-parent-cleanup');
+      addTearDown(DownloadKeyValue.instance.delete);
+
+      final mediaDirectory = await Directory.systemTemp.createTemp(
+        'attachment-util-test',
+      );
+      addTearDown(() => mediaDirectory.delete(recursive: true));
+
+      final util = AttachmentUtil(
+        Client(
+          baseUrl: 'http://127.0.0.1',
+          accessToken: 'test',
+          httpLogLevel: null,
+        ),
+        database.messageDao,
+        database.transcriptMessageDao,
+        SettingPropertyStorage(database.propertyDao),
+        mediaDirectory.path,
+      );
+
+      for (final key in const [
+        'target-parent|target-child',
+        'target-parent|other-child',
+        'sibling-parent|sibling-child',
+      ]) {
+        await DownloadKeyValue.instance.addMessageId(key);
+      }
+
+      expect(
+        util.downloadingParentIds.toSet(),
+        {'target-parent', 'sibling-parent'},
+      );
+
+      await util.removeAttachmentJobsByParentId('target-parent');
+
+      expect(
+        DownloadKeyValue.instance.messageIds.toSet(),
+        {'sibling-parent|sibling-child'},
+      );
+      expect(util.downloadingParentIds.toSet(), {'sibling-parent'});
+
+      expect(
+        await util.cancelProgressAttachmentJob(
+          'sibling-child',
+          transcriptId: 'sibling-parent',
+        ),
+        isFalse,
+      );
+      expect(DownloadKeyValue.instance.messageIds, isEmpty);
+    },
+  );
+}


### PR DESCRIPTION
## Problem
Historical transcript attachment rows can be missing media metadata. The download path could then fail before creating the attachment job. Repeated syncs could also use broad message identity and leave stale transcript jobs after parent deletion.

## Changes
- Restore downloads for historical transcript attachments with missing local media metadata.
- Normalize incoming transcript attachment state and omit local-only media fields from outgoing transcript payloads.
- Scope transcript attachment queries, status updates, progress, and jobs to `(transcriptId, messageId)`.
- Prevent duplicate downloads for the same `(transcriptId, messageId)` while a download is active or after it reaches `DONE`.
- Isolate transcript attachment files by `(transcriptId, messageId)` so simultaneous parent copies cannot overwrite one another.
- Clean composite transcript jobs during parent deletion and startup recovery without affecting sibling messages.
- Invalidate in-flight reservations so deletion or cancellation cannot recreate a stale attachment job.

## Validation
- `flutter test test/utils/attachment_util_test.dart` — 7 tests passed
- Targeted `flutter analyze` for the affected files — no issues