### PR TITLE
fix: show badges in mention panel

### DIFF
--- a/lib/widgets/mention_panel.dart
+++ b/lib/widgets/mention_panel.dart
@@ -15,6 +15,7 @@ import '../ui/provider/mention_provider.dart';
 import '../utils/extension/extension.dart';
 import '../utils/reg_exp_utils.dart';
 import 'avatar_view/avatar_view.dart';
+import 'conversation/badges_widget.dart';
 import 'high_light_text.dart';
 import 'interactive_decorated_box.dart';
 
@@ -218,47 +219,61 @@ class _MentionItem extends StatelessWidget {
             size: 32,
           ),
           const SizedBox(width: 6),
-          Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              CustomText(
-                user.fullName ?? '',
-                style: TextStyle(
-                  fontSize: 14,
-                  color: context.theme.text,
-                  height: 1,
-                ),
-                textMatchers: [
-                  EmojiTextMatcher(),
-                  if (keyword != null && keyword!.trim().isNotEmpty)
-                    MultiKeyWordTextMatcher.createKeywordMatcher(
-                      keyword: keyword!,
-                      style: TextStyle(color: context.theme.accent),
-                      caseSensitive: false,
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Flexible(
+                      child: CustomText(
+                        user.fullName ?? '',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: context.theme.text,
+                          height: 1,
+                        ),
+                        textMatchers: [
+                          EmojiTextMatcher(),
+                          if (keyword != null && keyword!.trim().isNotEmpty)
+                            MultiKeyWordTextMatcher.createKeywordMatcher(
+                              keyword: keyword!,
+                              style: TextStyle(color: context.theme.accent),
+                              caseSensitive: false,
+                            ),
+                        ],
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                     ),
-                ],
-                maxLines: 1,
-              ),
-              const SizedBox(height: 2),
-              CustomText(
-                user.identityNumber,
-                style: TextStyle(
-                  fontSize: 12,
-                  color: context.theme.secondaryText,
-                ),
-                textMatchers: [
-                  EmojiTextMatcher(),
-                  if (keyword != null && keyword!.trim().isNotEmpty)
-                    MultiKeyWordTextMatcher.createKeywordMatcher(
-                      keyword: keyword!,
-                      style: TextStyle(color: context.theme.accent),
-                      caseSensitive: false,
+                    BadgesWidget(
+                      verified: user.isVerified ?? false,
+                      isBot: user.isBot,
+                      membership: user.membership,
                     ),
-                ],
-                maxLines: 1,
-              ),
-            ],
+                  ],
+                ),
+                const SizedBox(height: 2),
+                CustomText(
+                  user.identityNumber,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: context.theme.secondaryText,
+                  ),
+                  textMatchers: [
+                    EmojiTextMatcher(),
+                    if (keyword != null && keyword!.trim().isNotEmpty)
+                      MultiKeyWordTextMatcher.createKeywordMatcher(
+                        keyword: keyword!,
+                        style: TextStyle(color: context.theme.accent),
+                        caseSensitive: false,
+                      ),
+                  ],
+                  maxLines: 1,
+                ),
+              ],
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- reuse the existing BadgesWidget in mention suggestions
- show membership, verified, and bot badges after user names
- truncate long names with an ellipsis

## Test
- dart format lib/widgets/mention_panel.dart
- flutter analyze lib/widgets/mention_panel.dart