### PR TITLE
fix: preserve side panel during message selection

### DIFF
--- a/lib/ui/home/chat/chat_page.dart
+++ b/lib/ui/home/chat/chat_page.dart
@@ -66,11 +66,6 @@ class ChatPage extends HookConsumerWidget {
 
     useValueListenable(chatSideNotifier);
 
-    ref.listen(hasSelectedMessageProvider, (previous, hasSelectedMessage) {
-      if (!hasSelectedMessage) return;
-      chatSideNotifier.clear();
-    });
-
     final chatContainerPage = MaterialPage(
       key: const ValueKey('chatContainer'),
       name: 'chatContainer',


### PR DESCRIPTION
Selecting a message closed the open side panel. Remove the selection listener that clears side navigation so the panel stays open during message selection.

Validation: all 6 existing chat page and side notifier tests passed; targeted Dart analysis passed. macOS interaction has not been manually verified.
