### PR TITLE
fix: preserve shareable app card buttons when forwarding

### DIFF
--- a/lib/widgets/message/item/action_card/action_card_data.dart
+++ b/lib/widgets/message/item/action_card/action_card_data.dart
@@ -1,6 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
 
-import '../../../../utils/uri_utils.dart';
 import '../action/action_data.dart';
 
 part 'action_card_data.g.dart';
@@ -92,18 +91,9 @@ class Cover {
 
 extension on ActionData {
   bool get isValidSharedAction {
-    try {
-      final uri = Uri.parse(action);
-      if (uri.isSendToUser) {
-        return true;
-      }
-      if ((uri.isScheme('http') || uri.isScheme('https')) &&
-          !uri.isHttpsSendUrl) {
-        return true;
-      }
-    } catch (err) {
-      return false;
-    }
-    return false;
+    final url = action.toLowerCase();
+    return !url.startsWith('mixin://send') &&
+        !url.startsWith('mixin://mixin.one/send') &&
+        !url.startsWith('https://mixin.one/send');
   }
 }

--- a/test/widgets/message/action_card_test.dart
+++ b/test/widgets/message/action_card_test.dart
@@ -3,6 +3,46 @@ import 'package:flutter_app/widgets/message/item/action_card/action_card_data.da
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('shared actions follow Android send-prefix exclusions', () {
+    final cases = {
+      'mixin://apps/example': true,
+      'MIXIN://users/example': true,
+      'https://example.com': true,
+      'http://example.com': true,
+      'custom://example': true,
+      'mixin://send?user=example': false,
+      'mixin://mixin.one/send?text=hello': false,
+      'https://mixin.one/send?user=example': false,
+      'MiXiN://SeNd': false,
+      'MIXIN://MIXIN.ONE/SEND': false,
+      'HTTPS://MIXIN.ONE/SEND': false,
+      'mixin://sender': false,
+    };
+    AppCardData card(List<String> actions) => AppCardData(
+      '',
+      '',
+      'title',
+      'description',
+      '',
+      '',
+      true,
+      actions.map((action) => ActionData('button', '', action)).toList(),
+      '',
+      null,
+    );
+    for (final entry in cases.entries) {
+      expect(card([entry.key]).canShareActions, entry.value, reason: entry.key);
+    }
+    expect(card([]).canShareActions, isTrue);
+    expect(
+      card([
+        'mixin://apps/example',
+        'mixin://send?user=example',
+      ]).canShareActions,
+      isFalse,
+    );
+  });
+
   test('test generate copy', () {
     final tests = [
       (


### PR DESCRIPTION
Forwarding an app card with non-send Mixin links stripped its buttons. Align the shared action check with MixinNetwork/android-app#6565 so those buttons survive both individual and transcript forwarding.

Exclude the case-insensitive prefixes `mixin://send`, `mixin://mixin.one/send`, and `https://mixin.one/send`. This also excludes send links with a user parameter, matching Android.

Validation: app card tests and targeted Dart analysis passed; macOS debug build and launch succeeded. Tests cover allowed links, all three exclusions, mixed case, prefix matching, empty actions, and mixed button groups.
