### PR TITLE
Validate the source of device transfer commands

### DIFF
--- a/lib/workers/decrypt_message.dart
+++ b/lib/workers/decrypt_message.dart
@@ -316,14 +316,27 @@ class DecryptMessage extends Injector {
           );
         }
       } else if (plainJsonMessage.action == kDeviceTransfer) {
-        final json =
-            jsonDecode(plainJsonMessage.content!) as Map<String, dynamic>;
-        final command = TransferDataCommand.fromJson(json);
-        if (_deviceTransfer == null) {
-          e('DeviceTransfer is null, but received command $command');
+        final deviceTransfer = _deviceTransfer;
+        if (deviceTransfer == null ||
+            !deviceTransfer.acceptsRemoteSource(
+              sourceUserId: data.userId,
+              senderId: data.senderId,
+              sessionId: data.sessionId,
+            )) {
+          w('Ignoring device transfer command from unexpected source');
+          return;
+        }
+        final TransferDataCommand command;
+        try {
+          final json =
+              jsonDecode(plainJsonMessage.content!) as Map<String, dynamic>;
+          command = TransferDataCommand.fromJson(json);
+        } catch (_) {
+          w('Ignoring malformed device transfer command');
+          return;
         }
         i('on device transfer command: $command');
-        _deviceTransfer?.handleRemoteCommand(command);
+        deviceTransfer.handleRemoteCommand(command);
       }
       await database.messageHistoryDao.insert(
         MessagesHistoryData(messageId: data.messageId),

--- a/lib/workers/device_transfer.dart
+++ b/lib/workers/device_transfer.dart
@@ -78,7 +78,22 @@ class DeviceTransferIsolateController {
   DeviceTransferIsolateController({
     required this.dispose,
     required this.handleRemoteCommand,
+    required this.userId,
+    required this.primarySessionId,
   });
+
+  final String userId;
+  final String primarySessionId;
+
+  bool acceptsRemoteSource({
+    required String sourceUserId,
+    required String senderId,
+    required String sessionId,
+  }) =>
+      sourceUserId == userId &&
+      senderId == userId &&
+      primarySessionId.isNotEmpty &&
+      sessionId == primarySessionId;
 
   final void Function() dispose;
 
@@ -132,6 +147,8 @@ Future<DeviceTransferIsolateController> startTransferIsolate({
     );
 
   return DeviceTransferIsolateController(
+    userId: userId,
+    primarySessionId: primarySessionId,
     dispose: () {
       isolateChannel.sink.add(DeviceTransferIsolateDestroy());
       jobSubscribers.forEach((element) => element.cancel());

--- a/test/utils/device_transfer_source_test.dart
+++ b/test/utils/device_transfer_source_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_app/workers/device_transfer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('migration accepts only the current account primary session', () {
+    final controller = DeviceTransferIsolateController(
+      dispose: () {},
+      handleRemoteCommand: (_) {},
+      userId: 'self',
+      primarySessionId: 'primary',
+    );
+    for (final source in [
+      ('self', 'self', 'primary', true),
+      ('other', 'other', 'primary', false),
+      ('self', 'other', 'primary', false),
+      ('other', 'self', 'primary', false),
+      ('self', 'self', 'desktop', false),
+      ('self', 'self', '', false),
+    ]) {
+      expect(
+        controller.acceptsRemoteSource(
+          sourceUserId: source.$1,
+          senderId: source.$2,
+          sessionId: source.$3,
+        ),
+        source.$4,
+      );
+    }
+  });
+}


### PR DESCRIPTION
Accept device transfer commands only when the source account and sender match the current account and the sending session is its primary session. Ignore unexpected sources and malformed commands before dispatch.

Validation: 5 source validation and transfer tests passed. Targeted static analysis passed. Mobile device interoperability has not been tested.
