### PR TITLE
Remove sensitive contents from diagnostic logs

### DIFF
--- a/lib/account/session_key_value.dart
+++ b/lib/account/session_key_value.dart
@@ -47,8 +47,6 @@ String? encryptPin(String code) {
     return null;
   }
 
-  d('pinToken: $pinToken');
-
   final pinBytes = Uint8List.fromList(utf8.encode(code));
   final timeBytes = Uint8List(8);
   final iteratorBytes = Uint8List(8);

--- a/lib/blaze/blaze.dart
+++ b/lib/blaze/blaze.dart
@@ -252,7 +252,7 @@ class Blaze {
               }
 
               _connectedState = ConnectedState.connected;
-              d('blazeMessage receive: ${blazeMessage.toJson()}');
+              d('blazeMessage receive: ${blazeMessage.action}');
 
               if (blazeMessage.action == kErrorAction &&
                   blazeMessage.error?.code == authentication) {
@@ -424,7 +424,7 @@ class Blaze {
         .getLastBlazeMessageCreatedAt();
     final param = offset?.toIso8601String();
     final m = createPendingBlazeMessage(BlazeMessageParamOffset(offset: param));
-    d('blaze send: ${m.toJson()}');
+    d('blaze send: ${m.action}');
     await _sendGZip(m);
   }
 
@@ -492,7 +492,7 @@ class Blaze {
       return null;
     }
 
-    d('blaze send: ${blazeMessage.toJson()}');
+    d('blaze send: ${blazeMessage.action}');
     final transaction = WebSocketTransaction<BlazeMessage>(blazeMessage.id);
     transactions[blazeMessage.id] = transaction;
     d('sendMessage transactions size: ${transactions.length}');
@@ -566,7 +566,7 @@ class Blaze {
     if (url == proxyConfig) {
       return;
     }
-    i('Proxy settings changed to: $url');
+    i('Proxy settings changed');
     proxyConfig = url;
 
     i('Triggering DISCONNECT event: Proxy settings changed');

--- a/lib/ui/landing/landing_mobile.dart
+++ b/lib/ui/landing/landing_mobile.dart
@@ -328,7 +328,7 @@ Future<VerificationResponse> _requestVerificationCode({
         assert(result.length == 2, 'Invalid result length');
         final type = result.first as CaptchaType;
         final token = result[1] as String;
-        d('Captcha type: $type, token: $token');
+        d('Captcha type: $type');
         return _requestVerificationCode(
           phone: phone,
           context: context,

--- a/lib/utils/device_transfer/device_transfer_receiver.dart
+++ b/lib/utils/device_transfer/device_transfer_receiver.dart
@@ -214,7 +214,6 @@ class DeviceTransferReceiver {
       switch (data.type) {
         case JsonTransferDataType.conversation:
           final conversation = TransferDataConversation.fromJson(data.data);
-          d('client: conversation: $conversation');
           final local = await database.conversationDao
               .conversationById(conversation.conversationId)
               .getSingleOrNull();
@@ -233,7 +232,6 @@ class DeviceTransferReceiver {
             return;
           }
 
-          d('client: message: $message');
           final local = await database.messageDao.findMessageByMessageId(
             message.messageId,
           );
@@ -248,40 +246,33 @@ class DeviceTransferReceiver {
           await database.ftsDatabase.insertFts(dbMessage);
         case JsonTransferDataType.asset:
           final asset = TransferDataAsset.fromJson(data.data);
-          d('client: asset: $asset');
           await database.assetDao.insertAsset(asset.toDbAsset());
         case JsonTransferDataType.token:
           final token = TransferDataToken.fromJson(data.data);
-          d('client: token: $token');
           await database.tokenDao.insertToken(token.toDbToken());
         case JsonTransferDataType.user:
           final user = TransferDataUser.fromJson(data.data);
-          d('client: user: $user');
           await database.userDao.insert(
             user.toDbUser(),
             updateIfConflict: false,
           );
         case JsonTransferDataType.sticker:
           final sticker = TransferDataSticker.fromJson(data.data);
-          d('client: sticker: $sticker');
           await database.stickerDao.insertSticker(sticker.toDbSticker());
         case JsonTransferDataType.snapshot:
           final snapshot = TransferDataSnapshot.fromJson(data.data);
-          d('client: snapshot: $snapshot');
           await database.snapshotDao.insert(
             snapshot.toDbSnapshot(),
             updateIfConflict: false,
           );
         case JsonTransferDataType.safeSnapshot:
           final safeSnapshot = TransferDataSafeSnapshot.fromJson(data.data);
-          d('client: safeSnapshot: $safeSnapshot');
           await database.safeSnapshotDao.insert(
             safeSnapshot.toDbSafeSnapshot(),
             updateIfConflict: false,
           );
         case JsonTransferDataType.expiredMessage:
           final expiredMessage = TransferDataExpiredMessage.fromJson(data.data);
-          d('client: expiredMessage: $expiredMessage');
           await database.expiredMessageDao.insert(
             messageId: expiredMessage.messageId,
             expireIn: expiredMessage.expireIn,
@@ -292,45 +283,38 @@ class DeviceTransferReceiver {
           final transcriptMessage = TransferDataTranscriptMessage.fromJson(
             data.data,
           );
-          d('client: transcriptMessage: $transcriptMessage');
           await database.transcriptMessageDao.insertAll([
             transcriptMessage.toDbTranscriptMessage(),
           ], mode: InsertMode.insertOrIgnore);
         case JsonTransferDataType.participant:
           final participant = TransferDataParticipant.fromJson(data.data);
-          d('client: participant: $participant');
           await database.participantDao.insert(
             participant.toDbParticipant(),
             updateIfConflict: false,
           );
         case JsonTransferDataType.pinMessage:
           final pinMessage = TransferDataPinMessage.fromJson(data.data);
-          d('client: pinMessage: $pinMessage');
           await database.pinMessageDao.insert(
             pinMessage.toDbPinMessage(),
             updateIfConflict: false,
           );
         case JsonTransferDataType.messageMention:
           final messageMention = db.MessageMention.fromJson(data.data);
-          d('client: messageMention: $messageMention');
           await database.messageMentionDao.insert(
             messageMention,
             updateIfConflict: false,
           );
         case JsonTransferDataType.app:
           final app = TransferDataApp.fromJson(data.data);
-          d('client: app: $app');
           await database.appDao.insert(app.toDbApp(), updateIfConflict: false);
         case JsonTransferDataType.inscriptionItem:
           final inscription = db.InscriptionItem.fromJson(data.data);
-          d('client: inscription: $inscription');
           await database.inscriptionItemDao.insert(
             inscription,
             updateIfConflict: false,
           );
         case JsonTransferDataType.inscriptionCollection:
           final collection = db.InscriptionCollection.fromJson(data.data);
-          d('client: InscriptionCollection: $collection');
           await database.inscriptionCollectionDao.insert(
             collection,
             updateIfConflict: false,
@@ -339,8 +323,11 @@ class DeviceTransferReceiver {
           i('unknown type: ${data.type}');
       }
     } catch (error, stacktrace) {
-      e('_processReceivedJsonPacket: ${data.data}');
-      e('_processReceivedJsonPacket', error, stacktrace);
+      e(
+        '_processReceivedJsonPacket: ${data.type} ${error.runtimeType}',
+        null,
+        stacktrace,
+      );
     }
   }
 

--- a/lib/utils/device_transfer/device_transfer_sender.dart
+++ b/lib/utils/device_transfer/device_transfer_sender.dart
@@ -165,8 +165,7 @@ class DeviceTransferSender {
                   });
                 } else {
                   e(
-                    'sender verify code failed. except $verificationCode, '
-                    'but got ${command.code}',
+                    'sender verify code failed',
                   );
                   for (final s in _pendingVerificationSockets) {
                     s

--- a/lib/utils/device_transfer/transfer_data_command.dart
+++ b/lib/utils/device_transfer/transfer_data_command.dart
@@ -131,6 +131,10 @@ class TransferDataCommand with Equatable {
   bool get isPull => action == kTransferCommandActionPull;
 
   @override
+  String toString() =>
+      'TransferDataCommand(action: $action, version: $version)';
+
+  @override
   List<Object?> get props => [
     deviceId,
     action,

--- a/lib/utils/device_transfer/transfer_protocol.dart
+++ b/lib/utils/device_transfer/transfer_protocol.dart
@@ -260,9 +260,15 @@ class _TransferJsonPacketBuilder extends _TransferPacketBuilder {
       return creator(jsonData);
     } catch (error, stacktrace) {
       e(
-        '_TransferJsonPacketBuilder#build: $error, $stacktrace \ncontent: ${utf8.decode(jsonData, allowMalformed: true)}',
+        '_TransferJsonPacketBuilder#build: ${error.runtimeType}',
+        null,
+        stacktrace,
       );
-      rethrow;
+      // Parser errors can include plaintext; callers also log propagated errors.
+      Error.throwWithStackTrace(
+        const FormatException('Invalid transfer packet'),
+        stacktrace,
+      );
     }
   }
 }

--- a/lib/utils/proxy.dart
+++ b/lib/utils/proxy.dart
@@ -47,12 +47,15 @@ class ProxyConfig with Equatable {
   Map<String, dynamic> toJson() => _$ProxyConfigToJson(this);
 
   @override
+  String toString() => 'ProxyConfig(type: $type)';
+
+  @override
   List<Object?> get props => [id, type, host, port, username, password];
 }
 
 extension DioProxyExt on Dio {
   void applyProxy(ProxyConfig? config) {
-    i('apply client proxy ${config?.toUri()}');
+    i('apply client proxy: ${config != null}');
     httpClientAdapter = _CustomHttpClientAdapterWrapper(config);
   }
 }

--- a/lib/widgets/user/verification_dialog.dart
+++ b/lib/widgets/user/verification_dialog.dart
@@ -112,7 +112,7 @@ Future<VerificationResponse> requestVerificationCode({
         assert(result.length == 2, 'Invalid result length');
         final type = result.first as CaptchaType;
         final token = result[1] as String;
-        d('Captcha type: $type, token: $token');
+        d('Captcha type: $type');
         return requestVerificationCode(
           phone: phone,
           context: context,

--- a/lib/workers/decrypt_message.dart
+++ b/lib/workers/decrypt_message.dart
@@ -144,7 +144,7 @@ class DecryptMessage extends Injector {
     final data = BlazeMessageData.fromJson(
       jsonDecode(floodMessage.data) as Map<String, dynamic>,
     );
-    d('DecryptMessage process data: ${data.toJson()}');
+    d('DecryptMessage process: ${data.messageId} ${data.category}');
     if (await isExistMessage(data.messageId)) {
       await _updateRemoteMessageStatus(data.messageId, MessageStatus.delivered);
       await database.floodMessageDao.deleteFloodMessage(floodMessage);

--- a/lib/workers/device_transfer.dart
+++ b/lib/workers/device_transfer.dart
@@ -470,7 +470,7 @@ class DeviceTransfer {
     int code,
     String secretKey,
   ) async {
-    d('_handleRemotePushCommand: $ip:$port ($code)');
+    d('_handleRemotePushCommand');
     final keyBytes = base64Decode(secretKey);
     if (keyBytes.length != 64) {
       e('handleRemotePushCommand: invalid secret key length.');

--- a/lib/workers/message_worker_isolate.dart
+++ b/lib/workers/message_worker_isolate.dart
@@ -279,7 +279,7 @@ class _MessageProcessRunner {
       _deviceTransfer = await startTransferIsolate(
         userId: userId,
         messageDeliver: (message) async {
-          d('device_transfer: send message: $message');
+          d('device_transfer: send message');
           final result = await _sender.deliver(message);
           if (!result.success) {
             w('device_transfer: send message failed: $result');

--- a/test/utils/sensitive_logs_test.dart
+++ b/test/utils/sensitive_logs_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_app/utils/device_transfer/transfer_data_command.dart';
+import 'package:flutter_app/utils/proxy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('proxy and transfer diagnostics omit credentials', () {
+    final proxy = ProxyConfig(
+      type: ProxyType.http,
+      host: 'localhost',
+      port: 8080,
+      id: 'proxy',
+      username: 'secret-user',
+      password: 'secret-password',
+    );
+    expect(proxy.toUri(), contains('secret-password'));
+    expect(proxy.toString(), isNot(contains('secret-user')));
+    expect(proxy.toString(), isNot(contains('secret-password')));
+    final command = TransferDataCommand.push(
+      ip: '127.0.0.1',
+      port: 1234,
+      deviceId: 'device',
+      code: 9876,
+      secretKey: 'secret-key',
+    );
+    expect(command.toJson()['secret_key'], 'secret-key');
+    expect(command.toString(), isNot(contains('secret-key')));
+    expect(command.toString(), isNot(contains('9876')));
+  });
+}

--- a/test/utils/transfer_protocol_test.dart
+++ b/test/utils/transfer_protocol_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
+import 'package:flutter_app/utils/crypto/aes.dart';
 import 'package:flutter_app/utils/device_transfer/cipher.dart';
 import 'package:flutter_app/utils/device_transfer/json_transfer_data.dart';
 import 'package:flutter_app/utils/device_transfer/socket_wrapper.dart';
@@ -41,6 +42,62 @@ Future<String> _createTempFile(int fileSize) async {
 }
 
 void main() {
+  test(
+    'invalid transfer packets do not expose decrypted content in logs',
+    () async {
+      const secret = 'transfer-key-must-not-appear';
+      final logs = <String>[];
+      final previousCallback = onWriteToFile;
+      onWriteToFile = logs.add;
+      try {
+        for (final payload in [
+          jsonEncode({'secret_key': secret, 'version': 'invalid'}),
+          '{"secret_key":"$secret",',
+        ]) {
+          final key = generateTransferKey();
+          final iv = generateTransferIv();
+          final encrypted = AesCipher.encrypt(
+            key: key.aesKey,
+            iv: iv,
+            data: Uint8List.fromList(utf8.encode(payload)),
+          );
+          final body = [...iv, ...encrypted];
+          final header = ByteData(5)
+            ..setInt8(0, kTypeCommand)
+            ..setInt32(1, body.length);
+          final packet = Uint8List.fromList([
+            ...header.buffer.asUint8List(),
+            ...body,
+            ...Hmac(sha256, key.hMacKey).convert(body).bytes,
+          ]);
+          final output = StreamController<TransferPacket>();
+          final subscription = output.stream.listen(
+            (_) => fail('Invalid packet accepted'),
+          );
+          final parser = TransferProtocolSink(output.sink, '', key);
+          Object? failure;
+          try {
+            parser.add(packet);
+          } catch (error, stackTrace) {
+            failure = error;
+            // The receiver logs propagated errors too.
+            e('receiver: socket process error', error, stackTrace);
+          } finally {
+            await output.close();
+            await subscription.cancel();
+          }
+          expect(failure, isNotNull);
+          expect(logs, isNotEmpty);
+          expect(logs.join('\n'), isNot(contains(secret)));
+          expect(failure.toString(), isNot(contains(secret)));
+          logs.clear();
+        }
+      } finally {
+        onWriteToFile = previousCallback;
+      }
+    },
+  );
+
   test('transfer writer', () async {
     final secretKey = generateTransferKey();
     final socket = MockTransferSocket(secretKey);


### PR DESCRIPTION
Remove credentials, keys, and message payloads from diagnostic output. Keep decrypted packet contents out of parser logs and propagated exceptions while preserving error types and stack traces for diagnosis.

Validation: 11 diagnostic, protocol, and transfer tests passed, including malformed encrypted packets. Static analysis passed after correcting test import ordering.
