### PR TITLE
Confirm external message links before sending

### DIFF
--- a/lib/utils/uri_utils.dart
+++ b/lib/utils/uri_utils.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/widgets.dart';
 import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -5,7 +7,6 @@ import 'package:url_launcher/url_launcher.dart';
 import '../constants/constants.dart';
 import '../crypto/uuid/uuid.dart';
 import '../db/mixin_database.dart' hide User;
-import '../enum/encrypt_category.dart';
 import '../ui/home/conversation/conversation_focus.dart';
 import '../widgets/conversation/conversation_dialog.dart';
 import '../widgets/message/item/action_card/action_card_data.dart';
@@ -27,9 +28,11 @@ Future<bool> openUriWithWebView(
   String? title,
   String? conversationId,
   AppCardData? appCardData,
+  bool isExplicitSendAction = false,
 }) async => openUri(
   context,
   text,
+  isExplicitSendAction: isExplicitSendAction,
   fallbackHandler: (uri) async {
     if (await MixinWebView.instance.isWebViewRuntimeAvailable()) {
       await MixinWebView.instance.openWebViewWindowWithUrl(
@@ -50,6 +53,8 @@ Future<bool> openUri(
   String text, {
   Future<bool> Function(Uri uri) fallbackHandler = launchUrl,
   App? app,
+  // Set only by an action-button tap, never from URI parameters.
+  bool isExplicitSendAction = false,
 }) async {
   final uri = Uri.parse(text);
   if (uri.scheme.isEmpty) return Future.value(false);
@@ -75,33 +80,15 @@ Future<bool> openUri(
     final startText = uri.startTextOfConversation;
     if (conversationId != null && conversationId.trim().isNotEmpty) {
       if (startText?.trim().isNotEmpty == true) {
-        try {
-          final conversation = await context.database.conversationDao
-              .conversationItem(conversationId)
-              .getSingleOrNull();
-
-          if (conversation == null) {
-            showToastFailed(null);
-            return false;
-          }
-
-          await ConversationFocus.selectConversation(
-            context,
-            conversation.conversationId,
-            conversation: conversation,
-          );
-
-          await context.accountServer.sendTextMessage(
-            startText ?? '',
-            EncryptCategory.plain,
-            conversationId: conversationId,
-          );
-
-          return true;
-        } catch (error) {
-          showToastFailed(error);
-          return false;
-        }
+        return showSendDialog(
+          context,
+          'text',
+          conversationId,
+          base64Encode(utf8.encode(startText!)),
+          app,
+          null,
+          isExplicitSendAction: isExplicitSendAction,
+        );
       }
 
       return _selectConversation(uri, context, conversationId);
@@ -115,6 +102,7 @@ Future<bool> openUri(
         uri.dataOfSend,
         app,
         uri.userOfSend,
+        isExplicitSendAction: isExplicitSendAction,
       );
     }
 

--- a/lib/widgets/auth.dart
+++ b/lib/widgets/auth.dart
@@ -23,6 +23,10 @@ const _lockDuration = Duration(minutes: 1);
 
 enum LockEvent { lock, unlock }
 
+final appLockedProvider = StateProvider.autoDispose<bool>(
+  (ref) => SecurityKeyValue.instance.hasPasscode,
+);
+
 class AuthGuard extends HookConsumerWidget {
   const AuthGuard({required this.child, super.key});
 
@@ -59,13 +63,14 @@ class _AuthGuard extends HookConsumerWidget {
         SecurityKeyValue.instance.biometric;
 
     final hasError = useState(false);
-    final lock = useState(SecurityKeyValue.instance.hasPasscode);
+    final lock = ref.watch(appLockedProvider.notifier);
+    ref.watch(appLockedProvider);
 
     useEffect(() {
       final listen = EventBus.instance.on.whereType<LockEvent>().listen((
         event,
       ) {
-        lock.value = event == LockEvent.lock;
+        lock.state = event == LockEvent.lock;
       });
 
       return listen.cancel;
@@ -79,7 +84,7 @@ class _AuthGuard extends HookConsumerWidget {
       }
 
       void listener() {
-        if (lock.value) return;
+        if (lock.state) return;
 
         final needLock = !isAppActive;
 
@@ -89,16 +94,16 @@ class _AuthGuard extends HookConsumerWidget {
           if (lockDuration.inMinutes > 0) {
             timer = Timer(lockDuration, () {
               if (!hasPasscode) {
-                lock.value = false;
+                lock.state = false;
                 return;
               }
 
-              lock.value = !isAppActive;
+              lock.state = !isAppActive;
             });
           }
         } else {
           dispose();
-          lock.value = needLock;
+          lock.state = needLock;
         }
       }
 
@@ -130,12 +135,12 @@ class _AuthGuard extends HookConsumerWidget {
         FocusManager.instance.removeListener(listener);
         ServicesBinding.instance.keyboard.removeHandler(handler);
       };
-    }, [lock.value]);
+    }, [lock.state]);
 
     return Stack(
       children: [
         child,
-        if (lock.value)
+        if (lock.state)
           GestureDetector(
             onTap: focusNode.requestFocus,
             behavior: HitTestBehavior.translucent,
@@ -201,7 +206,7 @@ class _AuthGuard extends HookConsumerWidget {
                             onCompleted: (value) {
                               textEditingController.text = '';
                               if (SecurityKeyValue.instance.passcode == value) {
-                                lock.value = false;
+                                lock.state = false;
                               } else {
                                 hasError.value = true;
                               }
@@ -235,7 +240,7 @@ class _AuthGuard extends HookConsumerWidget {
                               padding: const EdgeInsets.all(24),
                               onTap: () async {
                                 if (await authenticate()) {
-                                  lock.value = false;
+                                  lock.state = false;
                                   return;
                                 }
                               },

--- a/lib/widgets/message/item/action/action_message.dart
+++ b/lib/widgets/message/item/action/action_message.dart
@@ -137,6 +137,7 @@ class ActionMessageButton extends HookConsumerWidget {
           context,
           action.action,
           title: action.label,
+          isExplicitSendAction: true,
           conversationId: ref.read(currentConversationIdProvider),
         );
       },

--- a/lib/widgets/message/item/action_card/action_message.dart
+++ b/lib/widgets/message/item/action_card/action_message.dart
@@ -51,6 +51,7 @@ class ActionCardMessage extends HookConsumerWidget {
             context,
             appCardData.action,
             title: appCardData.title,
+            isExplicitSendAction: true,
             appCardData: appCardData,
             conversationId: ref.read(currentConversationIdProvider),
           );

--- a/lib/widgets/message/send_message_dialog/send_message_dialog.dart
+++ b/lib/widgets/message/send_message_dialog/send_message_dialog.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart';
@@ -10,15 +9,16 @@ import '../../../db/dao/sticker_dao.dart';
 import '../../../db/mixin_database.dart';
 import '../../../enum/encrypt_category.dart';
 import '../../../ui/home/conversation/conversation_focus.dart';
+import '../../../ui/provider/account_server_provider.dart';
 import '../../../ui/provider/conversation_provider.dart';
 import '../../../utils/extension/extension.dart';
 import '../../../utils/hook.dart';
 import '../../../utils/load_balancer_utils.dart';
 import '../../../utils/logger.dart';
 import '../../app_bar.dart';
+import '../../auth.dart';
 import '../../buttons.dart';
 import '../../dialog.dart';
-import '../../mixin_image.dart';
 import '../../sticker_page/sticker_item.dart';
 import '../../toast.dart';
 import '../../user_selector/conversation_selector.dart';
@@ -43,7 +43,9 @@ enum _Category {
 }
 
 extension _CategoriesExtension on String {
-  _Category? get category => _Category.values.byName(toLowerCase());
+  _Category? get category => _Category.values
+      .where((value) => value.name == toLowerCase())
+      .firstOrNull;
 }
 
 Future<bool> showSendDialog(
@@ -52,8 +54,13 @@ Future<bool> showSendDialog(
   String? conversationId,
   String? data,
   App? app,
-  String? user,
-) async {
+  String? user, {
+  bool isExplicitSendAction = false,
+}) async {
+  final container = context.providerContainer;
+  if (container.read(appLockedProvider)) return false;
+  final sendingAccount = context.accountServer;
+  final currentConversation = container.read(conversationProvider);
   final _category = category?.category;
   if (_category == null || data == null || data.isEmpty) return false;
 
@@ -67,6 +74,13 @@ Future<bool> showSendDialog(
           final json =
               await jsonDecodeWithIsolate(_data) as Map<String, dynamic>;
           result = SendImageData.fromJson(json);
+          final url = Uri.tryParse((result as SendImageData).url);
+          if (url == null ||
+              !url.hasAuthority ||
+              url.host.isEmpty ||
+              (url.scheme != 'http' && url.scheme != 'https')) {
+            return false;
+          }
         }
       case _Category.contact:
         {
@@ -96,82 +110,116 @@ Future<bool> showSendDialog(
         result = _data;
     }
   } catch (e, s) {
-    w('showSendDialog error: $e, $s');
+    w('showSendDialog error: ${e.runtimeType}, $s');
     return false;
   }
 
-  if (user != null) {
-    return _sendMessageToUserId(context, user, _category, result);
+  var targetId = conversationId;
+  var recipientId = user;
+  String? targetName;
+  EncryptCategory? encryptCategory;
+  final directAction =
+      isExplicitSendAction &&
+      (user != null ||
+          (conversationId == null &&
+              _category == _Category.text &&
+              currentConversation != null));
+  if (recipientId == null && targetId == null && _category == _Category.text) {
+    targetId = currentConversation?.conversationId;
+    recipientId = currentConversation?.userId;
   }
-  if (conversationId == null && _category == _Category.text) {
-    final currentConversation = context.providerContainer.read(
-      conversationProvider,
+  if (recipientId == null && targetId == null) {
+    final selected = (await showConversationSelector(
+      context: context,
+      singleSelect: true,
+      title: context.l10n.forward,
+      onlyContact: false,
+    ))?.firstOrNull;
+    if (selected == null) return false;
+    targetId = selected.conversationId;
+    recipientId = selected.userId;
+  }
+  if (recipientId != null) {
+    if (!Uuid.isValidUUID(fromString: recipientId)) return false;
+    final users = await context.accountServer.refreshUsers([recipientId]);
+    if (users == null || users.isEmpty) return false;
+    final targetUser = users.first;
+    targetName =
+        '${targetUser.fullName ?? recipientId} (${targetUser.identityNumber})';
+    targetId = generateConversationId(
+      context.accountServer.userId,
+      recipientId,
     );
-    if (currentConversation != null) {
-      await _sendMessage(
-        context,
-        currentConversation.conversationId,
-        currentConversation.encryptCategory,
-        _category,
-        result,
-      );
-      return true;
-    }
+    encryptCategory = await context.database.conversationDao.getEncryptCategory(
+      recipientId,
+      targetUser.isBot,
+    );
+  } else if (targetId != null) {
+    final conversation = await context.database.conversationDao
+        .conversationItem(targetId)
+        .getSingleOrNull();
+    if (conversation == null || conversation.ownerId == null) return false;
+    targetName = conversation.validName;
+    encryptCategory = conversation.isGroupConversation
+        ? EncryptCategory.signal
+        : await context.database.conversationDao.getEncryptCategory(
+            conversation.ownerId!,
+            conversation.isBotConversation,
+          );
   }
-
-  await showMixinDialog(
-    context: context,
-    child: _SendPage(_category, conversationId, result, app),
-  );
-
-  return true;
-}
-
-Future<bool> _sendMessageToUserId(
-  BuildContext context,
-  String userId,
-  _Category category,
-  dynamic data,
-) async {
-  if (!Uuid.isValidUUID(fromString: userId)) {
+  if (targetId == null ||
+      targetName == null ||
+      encryptCategory == null ||
+      !context.mounted ||
+      container.read(appLockedProvider)) {
     return false;
   }
 
-  showToastLoading();
-  try {
-    final users = await context.accountServer.refreshUsers([userId]);
-    if (users == null || users.isEmpty) {
-      return false;
+  final destination = targetId;
+  final encryption = encryptCategory;
+  Future<void> send() async {
+    if (!context.mounted ||
+        container.read(appLockedProvider) ||
+        !identical(
+          container.read(accountServerProvider).valueOrNull,
+          sendingAccount,
+        )) {
+      return;
     }
-  } finally {
-    Toast.dismiss();
+    await _sendMessage(
+      context,
+      destination,
+      encryption,
+      _category,
+      result,
+      recipientId: recipientId,
+    );
   }
 
-  final conversationId = generateConversationId(
-    context.accountServer.userId,
-    userId,
-  );
-  await ConversationFocus.selectUser(context, userId);
-  final conversation = context.providerContainer.read(conversationProvider);
-  if (conversation == null) {
-    return false;
+  if (directAction) {
+    if (user != null) await ConversationFocus.selectUser(context, user);
+    await send();
+  } else {
+    await showMixinDialog<void>(
+      context: context,
+      child: _SendPage(_category, result, app, targetName, send),
+    );
   }
-  await _sendMessage(
-    context,
-    conversationId,
-    conversation.encryptCategory,
-    category,
-    data,
-    recipientId: userId,
-  );
   return true;
 }
 
 class _SendPage extends HookConsumerWidget {
-  const _SendPage(this.category, this.conversationId, this.data, this.app);
+  const _SendPage(
+    this.category,
+    this.data,
+    this.app,
+    this.targetName,
+    this.onSend,
+  );
 
   final _Category category;
-  final String? conversationId;
+  final String targetName;
+  final Future<void> Function() onSend;
   final dynamic data;
   final App? app;
 
@@ -213,40 +261,16 @@ class _SendPage extends HookConsumerWidget {
       return _Text(data as String);
     }, [category, data]);
 
+    final sending = useState(false);
     Future<void> sendMessage() async {
-      EncryptCategory? encryptCategory;
-      var _conversationId = conversationId;
-      if (_conversationId == null) {
-        final result = await showConversationSelector(
-          context: context,
-          singleSelect: true,
-          title: context.l10n.forward,
-          onlyContact: false,
-        );
-        _conversationId = result?.firstOrNull?.conversationId;
-        encryptCategory = result?.firstOrNull?.encryptCategory;
+      if (sending.value || ref.read(appLockedProvider)) return;
+      sending.value = true;
+      try {
+        await onSend();
+        if (context.mounted) Navigator.pop(context);
+      } finally {
+        if (context.mounted) sending.value = false;
       }
-      if (encryptCategory == null && _conversationId != null) {
-        final conversation = await context.database.conversationDao
-            .conversationItem(_conversationId)
-            .getSingleOrNull();
-        final ownerId = conversation?.ownerId;
-        final isBotConversation = conversation?.isBotConversation;
-        if (ownerId == null || isBotConversation == null) return;
-        encryptCategory = await context.database.conversationDao
-            .getEncryptCategory(ownerId, isBotConversation);
-      }
-
-      if (_conversationId == null || encryptCategory == null) return;
-
-      await _sendMessage(
-        context,
-        _conversationId,
-        encryptCategory,
-        category,
-        data,
-      );
-      Navigator.pop(context);
     }
 
     return SizedBox(
@@ -260,6 +284,8 @@ class _SendPage extends HookConsumerWidget {
             leading: const SizedBox(),
             backgroundColor: context.theme.popUp,
           ),
+          const SizedBox(height: 12),
+          Text(targetName, textAlign: TextAlign.center),
           const SizedBox(height: 12),
           Container(
             width: 340,
@@ -279,12 +305,8 @@ class _SendPage extends HookConsumerWidget {
           ),
           const SizedBox(height: 54),
           MixinButton(
-            onTap: sendMessage,
-            child: Text(
-              (conversationId != null)
-                  ? context.l10n.send
-                  : context.l10n.forward,
-            ),
+            onTap: sending.value ? null : sendMessage,
+            child: Text(context.l10n.send),
           ),
           const SizedBox(height: 56),
         ],
@@ -402,12 +424,14 @@ class _Text extends StatelessWidget {
   final String text;
 
   @override
-  Widget build(BuildContext context) => _MessageBubble(
-    child: Text(
-      text,
-      style: TextStyle(
-        fontSize: MessageItemWidget.primaryFontSize,
-        color: context.theme.text,
+  Widget build(BuildContext context) => SingleChildScrollView(
+    child: _MessageBubble(
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: MessageItemWidget.primaryFontSize,
+          color: context.theme.text,
+        ),
       ),
     ),
   );
@@ -419,9 +443,11 @@ class _Image extends HookConsumerWidget {
   final SendImageData image;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) => MixinImage.network(
-    image.url,
-    placeholder: () => ColoredBox(color: context.theme.secondaryText),
+  Widget build(BuildContext context, WidgetRef ref) => SingleChildScrollView(
+    child: SelectableText(
+      image.url,
+      style: TextStyle(color: context.theme.text),
+    ),
   );
 }
 

--- a/lib/widgets/message/send_message_dialog/send_message_dialog.dart
+++ b/lib/widgets/message/send_message_dialog/send_message_dialog.dart
@@ -19,6 +19,7 @@ import '../../app_bar.dart';
 import '../../auth.dart';
 import '../../buttons.dart';
 import '../../dialog.dart';
+import '../../mixin_image.dart';
 import '../../sticker_page/sticker_item.dart';
 import '../../toast.dart';
 import '../../user_selector/conversation_selector.dart';
@@ -443,11 +444,9 @@ class _Image extends HookConsumerWidget {
   final SendImageData image;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) => SingleChildScrollView(
-    child: SelectableText(
-      image.url,
-      style: TextStyle(color: context.theme.text),
-    ),
+  Widget build(BuildContext context, WidgetRef ref) => MixinImage.network(
+    image.url,
+    placeholder: () => ColoredBox(color: context.theme.secondaryText),
   );
 }
 

--- a/test/widgets/message/send_link_test.dart
+++ b/test/widgets/message/send_link_test.dart
@@ -1,0 +1,358 @@
+@TestOn('linux || mac-os')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_app/account/account_server.dart';
+import 'package:flutter_app/constants/brightness_theme_data.dart';
+import 'package:flutter_app/db/database.dart';
+import 'package:flutter_app/db/fts_database.dart';
+import 'package:flutter_app/db/mixin_database.dart';
+import 'package:flutter_app/enum/encrypt_category.dart';
+import 'package:flutter_app/generated/l10n.dart';
+import 'package:flutter_app/ui/home/notifier/conversation_list_controller.dart';
+import 'package:flutter_app/ui/provider/account_server_provider.dart';
+import 'package:flutter_app/ui/provider/conversation_provider.dart';
+import 'package:flutter_app/ui/provider/database_provider.dart';
+import 'package:flutter_app/utils/event_bus.dart';
+import 'package:flutter_app/utils/uri_utils.dart';
+import 'package:flutter_app/widgets/auth.dart';
+import 'package:flutter_app/widgets/brightness_observer.dart';
+import 'package:flutter_app/widgets/buttons.dart';
+import 'package:flutter_app/widgets/mixin_image.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mixin_bot_sdk_dart/mixin_bot_sdk_dart.dart' as sdk;
+import 'package:overlay_support/overlay_support.dart';
+import 'package:provider/provider.dart' as provider;
+
+const _user = '00000000-0000-4000-8000-000000000001';
+const _self = '00000000-0000-4000-8000-000000000002';
+const _conversation = '00000000-0000-4000-8000-000000000003';
+
+class _ConversationList extends ValueNotifier<ConversationListState>
+    implements ConversationListController {
+  _ConversationList() : super(const ConversationListState());
+  @override
+  ConversationListState get state => const ConversationListState();
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _Server implements AccountServer {
+  final sent = <Invocation>[];
+  @override
+  String get userId => _self;
+  @override
+  Future<List<User>?> refreshUsers(
+    List<String> ids, {
+    bool force = false,
+  }) async => [
+    const User(userId: _user, identityNumber: '7001', fullName: 'Alice'),
+  ];
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #sendTextMessage ||
+        invocation.memberName == #sendImageMessageByUrl) {
+      sent.add(invocation);
+      return Future<void>.value();
+    }
+    return super.noSuchMethod(invocation);
+  }
+}
+
+class _ServerState extends StateNotifier<AsyncValue<AccountServer>>
+    implements AccountServerOpener {
+  _ServerState(AccountServer server) : super(AsyncValue.data(server));
+  void replace(AccountServer server) => state = AsyncValue.data(server);
+  @override
+  Future<void> dispose() async => super.dispose();
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _DatabaseState extends StateNotifier<AsyncValue<Database>>
+    implements DatabaseOpener {
+  _DatabaseState(Database database) : super(AsyncValue.data(database));
+  @override
+  Future<void> dispose() async => super.dispose();
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ConversationState extends StateNotifier<ConversationState?>
+    implements ConversationStateNotifier {
+  _ConversationState()
+    : super(
+        const ConversationState(
+          conversationId: _conversation,
+          userId: _user,
+          refreshKey: 0,
+        ),
+      );
+  void clear() => state = null;
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #focus) {
+      state = invocation.positionalArguments.first as ConversationState;
+      return null;
+    }
+    return super.noSuchMethod(invocation);
+  }
+}
+
+void main() {
+  late Database database;
+  late _Server server;
+  late ProviderContainer container;
+  late BuildContext context;
+
+  setUpAll(EventBus.initialize);
+  setUp(() async {
+    database = Database(
+      MixinDatabase(NativeDatabase.memory()),
+      FtsDatabase(NativeDatabase.memory()),
+    );
+    server = _Server();
+    container = ProviderContainer(
+      overrides: [
+        appLockedProvider.overrideWith((ref) => false),
+        accountServerProvider.overrideWith((ref) => _ServerState(server)),
+        databaseProvider.overrideWith((ref) => _DatabaseState(database)),
+        conversationProvider.overrideWith((ref) => _ConversationState()),
+      ],
+    );
+    await database.mixinDatabase
+        .into(database.mixinDatabase.users)
+        .insert(
+          const User(userId: _user, identityNumber: '7001', fullName: 'Alice'),
+        );
+    await database.mixinDatabase
+        .into(database.mixinDatabase.conversations)
+        .insert(
+          Conversation(
+            conversationId: _conversation,
+            ownerId: _user,
+            category: sdk.ConversationCategory.contact,
+            createdAt: DateTime(2026),
+            status: sdk.ConversationStatus.success,
+          ),
+        );
+  });
+  tearDown(() async {
+    container.dispose();
+    await database.dispose();
+  });
+
+  Future<void> mount(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1100, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: BrightnessData(
+          value: 0,
+          brightnessThemeData: lightBrightnessThemeData,
+          child: OverlaySupport.global(
+            child: MaterialApp(
+              localizationsDelegates: const [Localization.delegate],
+              supportedLocales: Localization.delegate.supportedLocales,
+              home:
+                  provider.ListenableProvider<ConversationListController>.value(
+                    value: _ConversationList(),
+                    child: Consumer(
+                      builder: (ctx, ref, child) {
+                        ref
+                          ..watch(appLockedProvider)
+                          ..watch(accountServerProvider)
+                          ..watch(databaseProvider)
+                          ..watch(conversationProvider);
+                        context = ctx;
+                        return const Scaffold();
+                      },
+                    ),
+                  ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> open(
+    WidgetTester tester,
+    String url, {
+    bool explicit = false,
+  }) async {
+    await tester.runAsync(() async {
+      var done = false;
+      unawaited(
+        openUri(context, url, isExplicitSendAction: explicit).then((_) {
+          done = true;
+        }),
+      );
+      for (
+        var i = 0;
+        i < 100 && !done && !Navigator.of(context).canPop();
+        i++
+      ) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+      expect(done || Navigator.of(context).canPop(), isTrue);
+    });
+    await tester.pumpAndSettle();
+  }
+
+  String link(String category, String data, {bool user = true}) => Uri(
+    scheme: 'mixin',
+    host: 'send',
+    queryParameters: {
+      'category': category,
+      'data': base64Encode(utf8.encode(data)),
+      if (user) 'user': _user,
+    },
+  ).toString();
+
+  testWidgets('external text waits for confirmation and cancel does not send', (
+    tester,
+  ) async {
+    await mount(tester);
+    final longText = List.filled(200, 'hello').join('\n');
+    await open(tester, '${link('text', longText)}&isExplicitSendAction=true');
+    expect(server.sent, isEmpty);
+    expect(find.text(longText), findsOneWidget);
+    expect(find.text('Alice (7001)'), findsOneWidget);
+    await tester.tap(find.byType(MixinCloseButton));
+    await tester.pumpAndSettle();
+    expect(server.sent, isEmpty);
+    await open(tester, link('text', 'hello'));
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+    expect(server.sent, hasLength(1));
+    expect(server.sent.single.namedArguments[#recipientId], _user);
+  });
+
+  testWidgets('image confirmation shows URL without loading a preview', (
+    tester,
+  ) async {
+    await mount(tester);
+    const url = 'http://127.0.0.1:12345/private.jpg';
+    await open(tester, link('image', jsonEncode({'url': url})));
+    expect(server.sent, isEmpty);
+    expect(find.text(url), findsOneWidget);
+    expect(find.byType(MixinImage), findsNothing);
+    await tester.tap(find.byType(MixinCloseButton));
+    await tester.pumpAndSettle();
+    expect(server.sent, isEmpty);
+    await open(tester, link('image', jsonEncode({'url': url})));
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+    expect(server.sent.single.memberName, #sendImageMessageByUrl);
+    server.sent.clear();
+    await open(
+      tester,
+      link('image', jsonEncode({'url': 'file:///private.jpg'})),
+    );
+    expect(Navigator.of(context).canPop(), isFalse);
+    expect(server.sent, isEmpty);
+  });
+
+  testWidgets('current recipient stays fixed and explicit action still sends', (
+    tester,
+  ) async {
+    await mount(tester);
+    await open(tester, link('text', 'current', user: false));
+    expect(server.sent, isEmpty);
+    (container.read(conversationProvider.notifier) as _ConversationState)
+        .clear();
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+    expect(server.sent.single.namedArguments[#recipientId], _user);
+    await open(tester, link('text', 'action'), explicit: true);
+    expect(server.sent, hasLength(2));
+  });
+
+  testWidgets('confirmation cannot send from a replacement account', (
+    tester,
+  ) async {
+    await mount(tester);
+    await open(tester, link('text', 'hello'));
+    final replacement = _Server();
+    (container.read(accountServerProvider.notifier) as _ServerState).replace(
+      replacement,
+    );
+    await tester.pump();
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+    expect(server.sent, isEmpty);
+    expect(replacement.sent, isEmpty);
+  });
+
+  testWidgets(
+    'group start remains Signal when its owner has an encrypted app',
+    (tester) async {
+      await database.mixinDatabase
+          .into(database.mixinDatabase.apps)
+          .insert(
+            const App(
+              appId: _user,
+              appNumber: '7001',
+              homeUri: '',
+              redirectUri: '',
+              name: 'App',
+              iconUrl: '',
+              description: '',
+              appSecret: '',
+              creatorId: _self,
+              capabilities: 'ENCRYPTED',
+            ),
+          );
+      const group = '00000000-0000-4000-8000-000000000004';
+      await database.mixinDatabase
+          .into(database.mixinDatabase.conversations)
+          .insert(
+            Conversation(
+              conversationId: group,
+              ownerId: _user,
+              name: 'Group',
+              category: sdk.ConversationCategory.group,
+              createdAt: DateTime(2026),
+              status: sdk.ConversationStatus.success,
+            ),
+          );
+      await mount(tester);
+      await open(tester, 'mixin://conversations/$group?start=hello');
+      expect(server.sent, isEmpty);
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+      expect(server.sent.single.positionalArguments[1], EncryptCategory.signal);
+    },
+  );
+
+  testWidgets(
+    'start uses confirmation and conversation encryption; lock blocks send',
+    (tester) async {
+      await mount(tester);
+      await open(tester, 'mixin://conversations/$_conversation?start=hello');
+      expect(server.sent, isEmpty);
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+      expect(server.sent.single.positionalArguments[1], EncryptCategory.signal);
+      await open(tester, link('text', 'locked'));
+      container.read(appLockedProvider.notifier).state = true;
+      await tester.pump();
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+      expect(server.sent, hasLength(1));
+      await tester.tap(find.byType(MixinCloseButton));
+      await tester.pumpAndSettle();
+      await open(tester, link('text', 'locked'));
+      expect(Navigator.of(context).canPop(), isFalse);
+    },
+  );
+}

--- a/test/widgets/message/send_link_test.dart
+++ b/test/widgets/message/send_link_test.dart
@@ -237,15 +237,16 @@ void main() {
     expect(server.sent.single.namedArguments[#recipientId], _user);
   });
 
-  testWidgets('image confirmation shows URL without loading a preview', (
+  testWidgets('image preview is shown but sending requires confirmation', (
     tester,
   ) async {
     await mount(tester);
     const url = 'http://127.0.0.1:12345/private.jpg';
     await open(tester, link('image', jsonEncode({'url': url})));
     expect(server.sent, isEmpty);
-    expect(find.text(url), findsOneWidget);
-    expect(find.byType(MixinImage), findsNothing);
+    expect(find.byType(MixinImage), findsOneWidget);
+    final preview = tester.widget<MixinImage>(find.byType(MixinImage));
+    expect((preview.image as NetworkImage).url, url);
     await tester.tap(find.byType(MixinCloseButton));
     await tester.pumpAndSettle();
     expect(server.sent, isEmpty);


### PR DESCRIPTION
Require recipient and content confirmation for external send and conversation-start links while preserving direct sending from existing action buttons. Use the destination conversation's encryption and prevent pending confirmation from sending while locked or after an account change.

Validation: 32 message link, message context, and Markdown tests passed. Targeted static analysis passed. Coverage includes image previews, cancellation, fixed recipients, account changes, locking, and Signal group messages.

